### PR TITLE
Fix wrong p10k path

### DIFF
--- a/zsh/.zshrc
+++ b/zsh/.zshrc
@@ -114,4 +114,3 @@ eval "$(uvx --generate-shell-completion zsh)"
 
 . "$HOME/.local/bin/env"
 source source ${ZSH_CUSTOM:-$HOME/.oh-my-zsh/custom}/themes/powerlevel10k/powerlevel10k.zsh-theme
-

--- a/zsh/.zshrc
+++ b/zsh/.zshrc
@@ -113,4 +113,5 @@ eval "$(uv generate-shell-completion zsh)"
 eval "$(uvx --generate-shell-completion zsh)"
 
 . "$HOME/.local/bin/env"
-source ~/powerlevel10k/powerlevel10k.zsh-theme
+source source ${ZSH_CUSTOM:-$HOME/.oh-my-zsh/custom}/themes/powerlevel10k/powerlevel10k.zsh-theme
+


### PR DESCRIPTION
Fixes wrong p10k path and takes the argument that is also in install_maca.sh