### PR TITLE
fix(iterm2): apply iTerm2 config for both minimal and full install

### DIFF
--- a/install_mac.sh
+++ b/install_mac.sh
@@ -167,13 +167,6 @@ else
 
     stow zsh nvim kitty yazi git ghostty zed
 
-    # 7.1 macOS Settings
-    if [[ "$OSTYPE" == "darwin"* ]]; then
-        echo ">>> Configuring iTerm2: Load preferences from dotfiles <<<"
-        defaults write com.googlecode.iterm2 PrefsCustomFolder -string "$DOTFILES_DIR/iterm2"
-        defaults write com.googlecode.iterm2 LoadPrefsFromCustomFolder -bool true
-    fi
-
     # Stow opencode config only if personal packages were installed
     if [[ $PERSONAL_INSTALL == "yes" ]]; then
         backup_if_exists ".config/opencode"
@@ -184,6 +177,13 @@ else
     echo ""
     echo ">>> Full installation successfully completed! <<<"
     echo ""
+fi
+
+# 8. macOS Settings (applies to both minimal and full install)
+if [[ "$OSTYPE" == "darwin"* ]]; then
+    echo ">>> Configuring iTerm2: Load preferences from dotfiles <<<"
+    defaults write com.googlecode.iterm2 PrefsCustomFolder -string "$DOTFILES_DIR/iterm2"
+    defaults write com.googlecode.iterm2 LoadPrefsFromCustomFolder -bool true
 fi
 
 echo ">>> Don't forget to set your git name and email! <<<"

--- a/iterm2/com.googlecode.iterm2.plist
+++ b/iterm2/com.googlecode.iterm2.plist
@@ -15,13 +15,13 @@
 	<key>AITermAPI</key>
 	<integer>2</integer>
 	<key>AIVectorStore</key>
-	<integer>1</integer>
+	<integer>0</integer>
 	<key>AiMaxTokens</key>
-	<integer>1000000</integer>
+	<integer>400000</integer>
 	<key>AiModel</key>
-	<string>gpt-4.1</string>
+	<string>gpt-5.2</string>
 	<key>AiResponseMaxTokens</key>
-	<integer>32768</integer>
+	<integer>128000</integer>
 	<key>AitermURL</key>
 	<string>https://api.openai.com/v1/responses</string>
 	<key>CopySelection</key>
@@ -1211,6 +1211,8 @@
 			<string>/Users/mezgerm</string>
 		</dict>
 	</array>
+	<key>OnlyWhenMoreTabs</key>
+	<false/>
 	<key>PointerActions</key>
 	<dict>
 		<key>Button,1,1,,</key>
@@ -1244,6 +1246,8 @@
 			<string>kNextWindowPointerAction</string>
 		</dict>
 	</dict>
+	<key>PromptOnQuit</key>
+	<false/>
 	<key>SoundForEsc</key>
 	<false/>
 	<key>SplitPaneDimmingAmount</key>


### PR DESCRIPTION
## Summary
- Moved iTerm2 `defaults write` commands outside the full/minimal install branch so they run for both install types
- Previously, minimal installs would install iTerm2 via Brewfile.minimal but skip configuring it to load preferences from the dotfiles directory
- Also includes updated iTerm2 plist preferences

## Test plan
- [ ] Run minimal install and verify iTerm2 loads custom preferences
- [ ] Run full install and verify iTerm2 still works as before