### PR TITLE
feat(hyprlock): refresh lock screen styling

### DIFF
--- a/hypr/.config/hypr/hyprlock.conf
+++ b/hypr/.config/hypr/hyprlock.conf
@@ -5,16 +5,41 @@ general {
 
 background {
   monitor =
-  color = rgba(08052bf2)
+  path = screenshot
+  blur_passes = 3
+  blur_size = 8
+  color = rgba(06101acc)
+}
+
+shape {
+  monitor =
+  size = 520, 320
+  color = rgba(09111fcc)
+  rounding = 24
+  border_size = 2
+  border_color = rgba(7dd3fc88)
+  position = 0, 0
+  halign = center
+  valign = center
+}
+
+shape {
+  monitor =
+  size = 520, 6
+  color = rgba(38bdf8ff)
+  rounding = 3
+  position = 0, -154
+  halign = center
+  valign = center
 }
 
 label {
   monitor =
   text = cmd[update:1000] echo "$(date +'%H:%M')"
   color = rgba(ffffffff)
-  font_size = 64
+  font_size = 72
   font_family = Cascadia Code
-  position = 0, 80
+  position = 0, 72
   halign = center
   valign = center
 }
@@ -22,30 +47,63 @@ label {
 label {
   monitor =
   text = cmd[update:1000] echo "$(date +'%A, %d %B %Y')"
-  color = rgba(ffffffcc)
-  font_size = 18
+  color = rgba(cbd5e1ff)
+  font_size = 20
   font_family = Cascadia Code
-  position = 0, 30
+  position = 0, 18
+  halign = center
+  valign = center
+}
+
+label {
+  monitor =
+  text = cmd[update:60000] echo "unlocking $(whoami)"
+  color = rgba(7dd3fcff)
+  font_size = 16
+  font_family = Cascadia Code
+  position = 0, -40
+  halign = center
+  valign = center
+}
+
+label {
+  monitor =
+  text = Type password to continue
+  color = rgba(94a3b8ff)
+  font_size = 14
+  font_family = Cascadia Code
+  position = 0, -128
   halign = center
   valign = center
 }
 
 input-field {
   monitor =
-  size = 260, 50
+  size = 320, 56
   outline_thickness = 2
   dots_size = 0.25
   dots_spacing = 0.3
   dots_center = true
-  outer_color = rgba(5294e2ff)
-  inner_color = rgba(08052be6)
+  outer_color = rgba(38bdf8ff)
+  inner_color = rgba(020617dd)
   font_color = rgba(ffffffff)
   fade_on_empty = false
-  placeholder_text = <span foreground="#b0b5bd">Locked</span>
+  placeholder_text = <span foreground="#94a3b8">Password</span>
   hide_input = false
-  check_color = rgba(5294e2ff)
-  fail_color = rgba(e53935ff)
-  position = 0, -40
+  check_color = rgba(22c55eff)
+  fail_color = rgba(f87171ff)
+  position = 0, -84
+  halign = center
+  valign = center
+}
+
+label {
+  monitor =
+  text = cmd[update:1000] echo "$(uptime -p | sed 's/^up //') uptime"
+  color = rgba(64748bff)
+  font_size = 13
+  font_family = Cascadia Code
+  position = 0, -182
   halign = center
   valign = center
 }


### PR DESCRIPTION
## Summary

  - refresh the Hyprlock screen with a blurred screenshot background
  - add a centered panel, accent bar, and improved typography
  - restyle the password field and status labels for a cleaner look