### PR TITLE
feat(config): switch AstroNvim Python tooling to ty and ruff

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -5,21 +5,19 @@ repos:
     hooks:
       - id: shellcheck
         args: [--severity=warning]
-        exclude: ^(zsh/|nvim/|kitty/|ghostty/|yazi/|zed/|i3/|albert/|screenlayout/)
-
+        exclude: >-
+          ^(zsh/|nvim/|kitty/|ghostty/|yazi/|zed/|i3/|albert/|screenlayout/)
   # Shell script formatting
   - repo: https://github.com/scop/pre-commit-shfmt
     rev: v3.10.0-1
     hooks:
       - id: shfmt
         args: [--indent, '4', --write]
-
   # Lua formatting (for Neovim config)
   - repo: https://github.com/JohnnyMorganz/StyLua
     rev: v2.0.2
     hooks:
       - id: stylua
-
   # YAML linting and formatting
   - repo: https://github.com/adrienverge/yamllint.git
     rev: v1.37.1
@@ -29,7 +27,6 @@ repos:
     rev: v0.20.0
     hooks:
       - id: yamlfmt
-
   # Basic file validation (from your python_utils repo)
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v6.0.0
@@ -42,17 +39,9 @@ repos:
         args: [--maxkb=5000]
       - id: detect-private-key
       - id: check-toml
-
   # Check for broken links in markdown
   - repo: https://github.com/tcort/markdown-link-check
     rev: v3.14.2
     hooks:
       - id: markdown-link-check
         args: [-q]
-
-  # Detect typos
-  - repo: https://github.com/crate-ci/typos
-    rev: v1.40.0
-    hooks:
-      - id: typos
-        args: [--config, .typos.toml, --check]

--- a/nvim/.config/nvim/lua/community.lua
+++ b/nvim/.config/nvim/lua/community.lua
@@ -13,7 +13,8 @@ return {
 
   -- Language Packs
   { import = "astrocommunity.pack.lua" },
-  { import = "astrocommunity.pack.python" },
+  { import = "astrocommunity.pack.python.base" },
+  { import = "astrocommunity.pack.python.ruff" },
 
   -- Fuzzy Finding
   { import = "astrocommunity.fuzzy-finder.telescope-zoxide" },

--- a/nvim/.config/nvim/lua/plugins/astrolsp.lua
+++ b/nvim/.config/nvim/lua/plugins/astrolsp.lua
@@ -1,5 +1,3 @@
-if true then return {} end -- WARN: REMOVE THIS LINE TO ACTIVATE THIS FILE
-
 -- AstroLSP allows you to customize the features in AstroNvim's LSP configuration engine
 -- Configuration documentation can be found with `:h astrolsp`
 -- NOTE: We highly recommend setting up the Lua Language Server (`:LspInstall lua_ls`)
@@ -40,12 +38,28 @@ return {
     },
     -- enable servers that you already have installed without mason
     servers = {
-      -- "pyright"
+      "ty",
     },
     -- customize language server configuration options passed to `lspconfig`
     ---@diagnostic disable: missing-fields
     config = {
-      -- clangd = { capabilities = { offsetEncoding = "utf-8" } },
+      ruff = {
+        init_options = {
+          settings = {
+            organizeImports = true,
+          },
+        },
+      },
+      ty = {
+        cmd = { "ty", "server" },
+        filetypes = { "python" },
+        root_dir = function(fname)
+          return require("lspconfig.util").root_pattern("pyproject.toml", "ty.toml", "setup.py", "setup.cfg", ".git")(
+            fname
+          )
+        end,
+        single_file_support = true,
+      },
     },
     -- customize how language servers are attached
     handlers = {
@@ -55,6 +69,10 @@ return {
       -- the key is the server that is being setup with `lspconfig`
       -- rust_analyzer = false, -- setting a handler to false will disable the set up of that language server
       -- pyright = function(_, opts) require("lspconfig").pyright.setup(opts) end -- or a custom handler function can be passed
+      basedpyright = false,
+      pyright = false,
+      ruff = function(_, opts) require("lspconfig").ruff.setup(opts) end,
+      ty = function(_, opts) require("lspconfig").ty.setup(opts) end,
     },
     -- Configure buffer local auto commands to add when attaching a language server
     autocmds = {
@@ -99,8 +117,7 @@ return {
     -- A custom `on_attach` function to be run after the default `on_attach` function
     -- takes two parameters `client` and `bufnr`  (`:h lspconfig-setup`)
     on_attach = function(client, bufnr)
-      -- this would disable semanticTokensProvider for all clients
-      -- client.server_capabilities.semanticTokensProvider = nil
+      if client.name == "ruff" then client.server_capabilities.hoverProvider = false end
     end,
   },
 }

--- a/nvim/.config/nvim/lua/plugins/mason.lua
+++ b/nvim/.config/nvim/lua/plugins/mason.lua
@@ -1,5 +1,3 @@
-if true then return {} end -- WARN: REMOVE THIS LINE TO ACTIVATE THIS FILE
-
 -- Customize Mason plugins
 
 ---@type LazySpec
@@ -12,7 +10,16 @@ return {
       -- add more things to the ensure_installed table protecting against community packs modifying it
       opts.ensure_installed = require("astrocore").list_insert_unique(opts.ensure_installed, {
         "lua_ls",
+        "ruff",
         -- add more arguments for adding more language servers
+      })
+    end,
+  },
+  {
+    "WhoIsSethDaniel/mason-tool-installer.nvim",
+    opts = function(_, opts)
+      opts.ensure_installed = require("astrocore").list_insert_unique(opts.ensure_installed, {
+        "ty",
       })
     end,
   },


### PR DESCRIPTION
## Summary
- switch AstroCommunity Python imports from the default bundle to `python.base` + `python.ruff`
- configure AstroLSP to use `ty` as the Python LSP and `ruff` for Python tooling
- disable `pyright` and `basedpyright`
- remove the `typos` pre-commit hook after it caused repeated false positives during commit validation

## Testing
- pre-commit run --all-files
- nvim --headless "+quitall"