### PR TITLE
feat(install): import shell history into atuin during setup

### DIFF
--- a/install_linux.sh
+++ b/install_linux.sh
@@ -249,7 +249,7 @@ if command -v atuin &>/dev/null; then
     echo ">>> Generating atuin completions <<<"
     atuin init zsh >"$COMPLETIONS_DIR/atuin-init.zsh"
     echo ">>> Importing shell history into atuin <<<"
-    atuin import auto
+    atuin import auto || echo ">>> Warning: Failed to import shell history into atuin. Please check atuin logs or run 'atuin import auto' manually. <<<"
 fi
 
 # Generate GitHub CLI completions

--- a/install_linux.sh
+++ b/install_linux.sh
@@ -249,7 +249,10 @@ if command -v atuin &>/dev/null; then
     echo ">>> Generating atuin completions <<<"
     atuin init zsh >"$COMPLETIONS_DIR/atuin-init.zsh"
     echo ">>> Importing shell history into atuin <<<"
-    atuin import auto || echo ">>> Warning: Failed to import shell history into atuin. Please check atuin logs or run 'atuin import auto' manually. <<<"
+    atuin import auto -y || {
+        echo ">>> Warning: Failed to import shell history into atuin."
+        echo ">>> Please check atuin logs or run 'atuin import auto' manually."
+    }
 fi
 
 # Generate GitHub CLI completions

--- a/install_linux.sh
+++ b/install_linux.sh
@@ -248,6 +248,8 @@ fi
 if command -v atuin &>/dev/null; then
     echo ">>> Generating atuin completions <<<"
     atuin init zsh >"$COMPLETIONS_DIR/atuin-init.zsh"
+    echo ">>> Importing shell history into atuin <<<"
+    atuin import auto
 fi
 
 # Generate GitHub CLI completions

--- a/install_mac.sh
+++ b/install_mac.sh
@@ -104,7 +104,10 @@ if command -v atuin &>/dev/null; then
     echo ">>> Generating atuin completions <<<"
     atuin init zsh >"$COMPLETIONS_DIR/atuin-init.zsh"
     echo ">>> Importing shell history into atuin <<<"
-    atuin import auto || echo ">>> Warning: Failed to import shell history into atuin. Please check atuin logs or run 'atuin import auto' manually. <<<"
+    atuin import auto -y || {
+        echo ">>> Warning: Failed to import shell history into atuin."
+        echo ">>> Please check atuin logs or run 'atuin import auto' manually."
+    }
 fi
 
 # Generate GitHub CLI completions

--- a/install_mac.sh
+++ b/install_mac.sh
@@ -104,7 +104,7 @@ if command -v atuin &>/dev/null; then
     echo ">>> Generating atuin completions <<<"
     atuin init zsh >"$COMPLETIONS_DIR/atuin-init.zsh"
     echo ">>> Importing shell history into atuin <<<"
-    atuin import auto
+    atuin import auto || echo ">>> Warning: Failed to import shell history into atuin. Please check atuin logs or run 'atuin import auto' manually. <<<"
 fi
 
 # Generate GitHub CLI completions

--- a/install_mac.sh
+++ b/install_mac.sh
@@ -103,6 +103,8 @@ fi
 if command -v atuin &>/dev/null; then
     echo ">>> Generating atuin completions <<<"
     atuin init zsh >"$COMPLETIONS_DIR/atuin-init.zsh"
+    echo ">>> Importing shell history into atuin <<<"
+    atuin import auto
 fi
 
 # Generate GitHub CLI completions

--- a/install_ubuntu_server.sh
+++ b/install_ubuntu_server.sh
@@ -161,7 +161,10 @@ fi
 if command -v atuin &>/dev/null; then
     atuin init zsh >"$COMPLETIONS_DIR/atuin-init.zsh"
     echo ">>> Importing shell history into atuin <<<"
-    atuin import auto || echo ">>> Warning: Failed to import shell history into atuin. Please check atuin logs or run 'atuin import auto' manually. <<<"
+    atuin import auto -y || {
+        echo ">>> Warning: Failed to import shell history into atuin."
+        echo ">>> Please check atuin logs or run 'atuin import auto' manually."
+    }
 fi
 
 # Set zsh as default shell

--- a/install_ubuntu_server.sh
+++ b/install_ubuntu_server.sh
@@ -161,7 +161,7 @@ fi
 if command -v atuin &>/dev/null; then
     atuin init zsh >"$COMPLETIONS_DIR/atuin-init.zsh"
     echo ">>> Importing shell history into atuin <<<"
-    atuin import auto
+    atuin import auto || echo ">>> Warning: Failed to import shell history into atuin. Please check atuin logs or run 'atuin import auto' manually. <<<"
 fi
 
 # Set zsh as default shell

--- a/install_ubuntu_server.sh
+++ b/install_ubuntu_server.sh
@@ -160,6 +160,8 @@ fi
 # Generate atuin init script
 if command -v atuin &>/dev/null; then
     atuin init zsh >"$COMPLETIONS_DIR/atuin-init.zsh"
+    echo ">>> Importing shell history into atuin <<<"
+    atuin import auto
 fi
 
 # Set zsh as default shell


### PR DESCRIPTION
## Summary
- Runs `atuin import auto` after generating atuin completions in all three install scripts (macOS, Arch Linux, Ubuntu Server)
- Preserves existing shell history by automatically importing zsh/bash/fish history into atuin on fresh setups