### PR TITLE
fix(install): preserve backups and use ai agent dotfiles

### DIFF
--- a/README.md
+++ b/README.md
@@ -198,7 +198,8 @@ stow zsh git nvim kitty yazi ghostty zed dunst hypr waybar
 stow zsh git nvim
 ```
 
-> **After installing main dotfiles**, set up AI agent configs from the separate repository:
+> **After installing main dotfiles**, set up AI agent configs from the separate repository.
+> The macOS installer does this automatically when you choose personal packages:
 > ```bash
 > git clone https://github.com/mfmezger/ai_agent_dotfiles.git ~/ai_agent_dotfiles
 > cd ~/ai_agent_dotfiles

--- a/install_mac.sh
+++ b/install_mac.sh
@@ -172,11 +172,23 @@ else
 
     stow zsh nvim kitty yazi git ghostty zed
 
-    # Stow opencode config only if personal packages were installed
+    # Install AI agent dotfiles from the dedicated repository for personal setups
     if [[ $PERSONAL_INSTALL == "yes" ]]; then
-        backup_if_exists ".config/opencode"
-        stow opencode
-        echo ">>> Stowing OpenCode configuration (personal install) <<<"
+        AI_AGENT_DOTFILES_DIR="$HOME/ai_agent_dotfiles"
+
+        if [[ ! -d "$AI_AGENT_DOTFILES_DIR" ]]; then
+            echo ">>> Cloning AI agent dotfiles to $AI_AGENT_DOTFILES_DIR <<<"
+            git clone https://github.com/mfmezger/ai_agent_dotfiles.git "$AI_AGENT_DOTFILES_DIR"
+        else
+            echo ">>> AI agent dotfiles already present at $AI_AGENT_DOTFILES_DIR <<<"
+        fi
+
+        if [[ -f "$AI_AGENT_DOTFILES_DIR/install.sh" ]]; then
+            echo ">>> Installing AI agent dotfiles from $AI_AGENT_DOTFILES_DIR <<<"
+            bash "$AI_AGENT_DOTFILES_DIR/install.sh"
+        else
+            echo ">>> Warning: $AI_AGENT_DOTFILES_DIR/install.sh not found. Skipping AI agent dotfiles setup. <<<"
+        fi
     fi
 
     echo ""

--- a/scripts/common.sh
+++ b/scripts/common.sh
@@ -3,8 +3,21 @@ set -e
 
 backup_if_exists() {
     local target="$HOME/$1"
+    local timestamp
+    local backup_path
+    local counter
+
     if [ -e "$target" ] && [ ! -L "$target" ]; then
-        echo "Backing up existing $target to $target.backup"
-        mv "$target" "$target.backup"
+        timestamp="$(date +"%Y%m%d-%H%M%S")"
+        backup_path="${target}.backup.${timestamp}"
+        counter=1
+
+        while [ -e "$backup_path" ]; do
+            backup_path="${target}.backup.${timestamp}.${counter}"
+            counter=$((counter + 1))
+        done
+
+        echo "Backing up existing $target to $backup_path"
+        mv "$target" "$backup_path"
     fi
 }


### PR DESCRIPTION
## Summary
- make installer backups timestamped so repeated runs do not overwrite earlier backups
- replace local opencode stow in the macOS personal install flow with cloning and running ai_agent_dotfiles/install.sh
- update README to document the macOS personal install behavior

## Validation
- bash -n scripts/common.sh install_mac.sh
- pre-commit run --all-files (all local hooks passed; markdown-link-check was skipped for commit because external URL checks are blocked in the sandbox)