### PR TITLE
feat(install): add rustup to setup scripts

### DIFF
--- a/install_linux.sh
+++ b/install_linux.sh
@@ -228,11 +228,25 @@ fi
 # Ensure uv is in PATH for this session
 export PATH="$HOME/.local/bin:$PATH"
 
+# ==============================================================================
+# 8. Install Rust Toolchain (rustup)
+# ==============================================================================
+echo ">>> Installing rustup <<<"
+if ! command -v rustup &>/dev/null; then
+    curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
+else
+    echo ">>> rustup already installed <<<"
+fi
+
+if [ -f "$HOME/.cargo/env" ]; then
+    . "$HOME/.cargo/env"
+fi
+
 echo ">>> Installing commitizen via uv <<<"
 uv tool install commitizen
 
 # ==============================================================================
-# 8. Generate Shell Completions (Pre-cached for faster shell startup)
+# 9. Generate Shell Completions (Pre-cached for faster shell startup)
 # ==============================================================================
 echo ">>> Generating shell completions <<<"
 COMPLETIONS_DIR="$HOME/.local/share/zsh/completions"
@@ -281,7 +295,7 @@ if command -v helm &>/dev/null; then
 fi
 
 # ==============================================================================
-# 9. Configure Docker
+# 10. Configure Docker
 # ==============================================================================
 echo ">>> Configuring Docker <<<"
 sudo systemctl enable docker.service
@@ -289,7 +303,7 @@ sudo systemctl start docker.service
 sudo usermod -aG docker "$USER"
 
 # ==============================================================================
-# 10. Security: ClamAV Antivirus
+# 11. Security: ClamAV Antivirus
 # ==============================================================================
 echo ">>> Setting up ClamAV antivirus <<<"
 sudo pacman -S --needed --noconfirm clamav
@@ -297,7 +311,7 @@ sudo systemctl enable clamav-freshclam
 sudo freshclam || echo ">>> Warning: freshclam update failed, will retry on next boot <<<"
 
 # ==============================================================================
-# 11. Security: Firewall (UFW)
+# 12. Security: Firewall (UFW)
 # ==============================================================================
 echo ">>> Configuring UFW firewall <<<"
 sudo pacman -S --needed --noconfirm ufw
@@ -311,14 +325,14 @@ sudo ufw allow ssh
 sudo ufw --force enable
 
 # ==============================================================================
-# 12. Security: Application Firewall (OpenSnitch)
+# 13. Security: Application Firewall (OpenSnitch)
 # ==============================================================================
 echo ">>> Setting up OpenSnitch application firewall <<<"
 sudo pacman -S --needed --noconfirm opensnitch
 sudo systemctl enable --now opensnitchd
 
 # ==============================================================================
-# 13. Link Dotfiles
+# 14. Link Dotfiles
 # ==============================================================================
 echo ">>> Linking dotfiles <<<"
 cd "$DOTFILES_DIR"
@@ -346,7 +360,7 @@ backup_if_exists ".gtkrc-2.0"
 stow zsh nvim yazi zellij git ghostty ekphos zed dunst hypr waybar rofi gtk
 
 # ==============================================================================
-# 14. Set Default Shell
+# 15. Set Default Shell
 # ==============================================================================
 echo ">>> Setting zsh as default shell <<<"
 if [ "$SHELL" != "$(which zsh)" ]; then

--- a/install_linux.sh
+++ b/install_linux.sh
@@ -233,7 +233,7 @@ export PATH="$HOME/.local/bin:$PATH"
 # ==============================================================================
 echo ">>> Installing rustup <<<"
 if ! command -v rustup &>/dev/null; then
-    curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
+    curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --no-modify-path
 else
     echo ">>> rustup already installed <<<"
 fi

--- a/install_linux.sh
+++ b/install_linux.sh
@@ -242,6 +242,13 @@ if [ -f "$HOME/.cargo/env" ]; then
     . "$HOME/.cargo/env"
 fi
 
+if ! cargo --version &>/dev/null; then
+    echo ">>> Configuring default Rust toolchain (stable) <<<"
+    rustup default stable
+else
+    echo ">>> Rust toolchain already configured <<<"
+fi
+
 echo ">>> Installing commitizen via uv <<<"
 uv tool install commitizen
 

--- a/install_mac.sh
+++ b/install_mac.sh
@@ -53,7 +53,23 @@ else
     echo ">>> uv already installed <<<"
 fi
 
-# 4. Install Oh My Zsh
+# 4. Install Rust toolchain (full install only)
+if [[ ! $MINIMAL_INSTALL =~ ^[Yy]$ ]]; then
+    echo ">>> Installing rustup <<<"
+    if ! command -v rustup &>/dev/null; then
+        curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
+    else
+        echo ">>> rustup already installed <<<"
+    fi
+
+    if [ -f "$HOME/.cargo/env" ]; then
+        . "$HOME/.cargo/env"
+    fi
+else
+    echo ">>> Skipping rustup for minimal install <<<"
+fi
+
+# 5. Install Oh My Zsh
 echo ">>> Installing Oh My Zsh <<<"
 if [ ! -d "$HOME/.oh-my-zsh" ]; then
     sh -c "$(curl -fsSL https://raw.githubusercontent.com/ohmyzsh/ohmyzsh/master/tools/install.sh)" "" --unattended
@@ -61,7 +77,7 @@ else
     echo ">>> Oh My Zsh already installed <<<"
 fi
 
-# 5. Install Zsh Plugins & Themes
+# 6. Install Zsh Plugins & Themes
 ZSH_CUSTOM="${ZSH_CUSTOM:-$HOME/.oh-my-zsh/custom}"
 
 echo ">>> Installing Powerlevel10k <<<"
@@ -85,7 +101,7 @@ else
     echo ">>> zsh-syntax-highlighting already installed <<<"
 fi
 
-# 6. Generate Static Completions (Pre-cached for faster shell startup)
+# 7. Generate Static Completions (Pre-cached for faster shell startup)
 echo ">>> Generating shell completions <<<"
 COMPLETIONS_DIR="$HOME/.local/share/zsh/completions"
 mkdir -p "$COMPLETIONS_DIR"
@@ -132,7 +148,7 @@ if [[ ! $MINIMAL_INSTALL =~ ^[Yy]$ ]] && command -v helm &>/dev/null; then
     helm completion zsh >"$COMPLETIONS_DIR/_helm"
 fi
 
-# 7. Link Dotfiles
+# 8. Link Dotfiles
 echo ">>> Linking dotfiles <<<"
 cd "$DOTFILES_DIR"
 
@@ -154,6 +170,7 @@ if [[ $MINIMAL_INSTALL =~ ^[Yy]$ ]]; then
     echo "  - Essential plugins: zsh-autosuggestions, zsh-syntax-highlighting, zsh-abbr"
     echo "  - Core tools: atuin, zoxide, eza, bat, yazi, stow"
     echo "  - Development: go, gh, git-delta, uv, fastfetch"
+    echo "  - Rust toolchain via rustup was skipped"
     echo "  - Nerd Font for Powerlevel10k icons"
     echo ""
     echo "What was NOT installed:"
@@ -178,16 +195,19 @@ else
     echo ""
     echo ">>> Full installation successfully completed! <<<"
     echo ""
+    echo "What was also installed:"
+    echo "  - Rust toolchain via rustup"
+    echo ""
 fi
 
-# 8. macOS Settings (applies to both minimal and full install)
+# 9. macOS Settings (applies to both minimal and full install)
 if [[ "$OSTYPE" == "darwin"* ]]; then
     echo ">>> Configuring iTerm2: Load preferences from dotfiles <<<"
     defaults write com.googlecode.iterm2 PrefsCustomFolder -string "$DOTFILES_DIR/iterm2"
     defaults write com.googlecode.iterm2 LoadPrefsFromCustomFolder -bool true
 fi
 
-# 9. Set Default Shell
+# 10. Set Default Shell
 echo ">>> Setting zsh as default shell <<<"
 ZSH_PATH="$(command -v zsh)"
 if [ "$SHELL" != "$ZSH_PATH" ]; then

--- a/install_mac.sh
+++ b/install_mac.sh
@@ -57,7 +57,7 @@ fi
 if [[ ! $MINIMAL_INSTALL =~ ^[Yy]$ ]]; then
     echo ">>> Installing rustup <<<"
     if ! command -v rustup &>/dev/null; then
-        curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
+        curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --no-modify-path
     else
         echo ">>> rustup already installed <<<"
     fi

--- a/install_mac.sh
+++ b/install_mac.sh
@@ -65,6 +65,13 @@ if [[ ! $MINIMAL_INSTALL =~ ^[Yy]$ ]]; then
     if [ -f "$HOME/.cargo/env" ]; then
         . "$HOME/.cargo/env"
     fi
+
+    if ! cargo --version &>/dev/null; then
+        echo ">>> Configuring default Rust toolchain (stable) <<<"
+        rustup default stable
+    else
+        echo ">>> Rust toolchain already configured <<<"
+    fi
 else
     echo ">>> Skipping rustup for minimal install <<<"
 fi

--- a/install_ubuntu_server.sh
+++ b/install_ubuntu_server.sh
@@ -100,7 +100,7 @@ export PATH="$HOME/.local/bin:$PATH"
 # Install Rust toolchain via rustup
 echo "🦀 Installing rustup..."
 if ! command -v rustup &>/dev/null; then
-    curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
+    curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --no-modify-path
 else
     echo "✅ rustup already installed"
 fi

--- a/install_ubuntu_server.sh
+++ b/install_ubuntu_server.sh
@@ -97,10 +97,12 @@ fi
 # Ensure uv is in PATH for this session
 export PATH="$HOME/.local/bin:$PATH"
 
-# Install Rust toolchain for ekphos
-echo "🦀 Installing Rust toolchain..."
-if ! command -v cargo &>/dev/null; then
+# Install Rust toolchain via rustup
+echo "🦀 Installing rustup..."
+if ! command -v rustup &>/dev/null; then
     curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
+else
+    echo "✅ rustup already installed"
 fi
 
 if [ -f "$HOME/.cargo/env" ]; then

--- a/install_ubuntu_server.sh
+++ b/install_ubuntu_server.sh
@@ -110,6 +110,13 @@ if [ -f "$HOME/.cargo/env" ]; then
     . "$HOME/.cargo/env"
 fi
 
+if ! cargo --version &>/dev/null; then
+    echo "🦀 Configuring default Rust toolchain (stable)..."
+    rustup default stable
+else
+    echo "✅ Rust toolchain already configured"
+fi
+
 # Install zellij terminal multiplexer
 echo "🪟 Installing zellij..."
 if ! command -v zellij &>/dev/null; then

--- a/zsh/.zshrc
+++ b/zsh/.zshrc
@@ -90,6 +90,11 @@ export LANG=en_US.UTF-8
 
 export EDITOR="nvim"
 
+# Rust toolchain installed via rustup
+if [[ -f "$HOME/.cargo/env" ]]; then
+    source "$HOME/.cargo/env"
+fi
+
 # To customize prompt, run `p10k configure` or edit ~/.p10k.zsh.
 [[ ! -f ~/.p10k.zsh ]] || source ~/.p10k.zsh
 

--- a/zsh/.zshrc
+++ b/zsh/.zshrc
@@ -90,6 +90,8 @@ export LANG=en_US.UTF-8
 
 export EDITOR="nvim"
 
+typeset -U path
+
 # Rust toolchain installed via rustup
 if [[ -f "$HOME/.cargo/env" ]]; then
     source "$HOME/.cargo/env"


### PR DESCRIPTION
## Summary
- add rustup installation to the mac, linux, and ubuntu install scripts
- install rustup on macOS only for full installs and skip it for minimal installs
- source ~/.cargo/env after install so cargo is available immediately
- source ~/.cargo/env from the tracked zsh config so Cargo stays on PATH after stow

## Validation
- zsh -n zsh/.zshrc
- bash -n install_mac.sh
- bash -n install_linux.sh
- bash -n install_ubuntu_server.sh