### PR TITLE
feat(zellij): add Alt tab shortcuts

### DIFF
--- a/zellij/.config/zellij/config.kdl
+++ b/zellij/.config/zellij/config.kdl
@@ -158,11 +158,12 @@ keybinds clear-defaults=true {
         bind "Alt k" { MoveFocus "up"; }
         bind "Alt l" { MoveFocusOrTab "right"; }
         bind "Alt n" { NewPane; }
-        bind "Alt o" { MoveTab "right"; }
-        bind "Alt p" { TogglePaneInGroup; }
+        bind "Alt o" { GoToPreviousTab; }
+        bind "Alt p" { GoToNextTab; }
         bind "Alt Shift p" { ToggleGroupMarking; }
         bind "Ctrl q" { Quit; }
         bind "Alt s" { NewPane "stacked"; }
+        bind "Alt t" { NewTab; }
     }
     shared_except "locked" "move" {
         bind "Ctrl h" { SwitchToMode "move"; }


### PR DESCRIPTION
## Summary
- add `Alt t` to create a new Zellij tab
- remap `Alt o` and `Alt p` to navigate to previous/next tabs
- leave unrelated local changes unstaged