### PR TITLE
docs(readme): split shortcuts and stow docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,36 +1,10 @@
 # 🔧 Dotfiles :rocket:
 
-Cross-platform dotfiles for macOS and Linux with modern CLI tools and development environment.
+Cross-platform dotfiles for macOS and Linux with modern CLI tools and a development-focused shell setup.
 
-> My recommended extensions for ai engineering can be installed via the vs-code extensions pack: [AI Engineering Extensions Pack](https://marketplace.visualstudio.com/items?itemName=mfmezger.python-ai-engineering).
+> My recommended extensions for AI engineering can be installed via the VS Code extensions pack: [AI Engineering Extensions Pack](https://marketplace.visualstudio.com/items?itemName=mfmezger.python-ai-engineering).
 
 > **AI Agents**: Claude Code and OpenCode configs are managed in the separate [ai_agent_dotfiles](https://github.com/mfmezger/ai_agent_dotfiles) repository.
-
-## Table of Contents
-
-- [Quick Install](#quick-install)
-  - [macOS](#macos)
-  - [Arch Linux / CachyOS](#arch-linux--cachyos)
-  - [Ubuntu (Minimal Setup)](#ubuntu-minimal-setup)
-- [Change Git Name and Email](#change-git-name-and-email)
-- [Key Tools](#key-tools)
-- [Structure](#structure)
-- [Shortcuts](#shortcuts)
-  - [Zellij](#zellij)
-  - [Basic](#basic)
-  - [Python / UV](#python--uv)
-  - [Git](#git)
-  - [Kubernetes](#kubernetes)
-  - [Docker](#docker)
-  - [System Update](#system-update)
-  - [File Listing (eza)](#file-listing-eza)
-- [Stow Usage](#stow-usage)
-  - [Stow Packages](#stow-packages)
-  - [Apply Configs](#apply-configs)
-  - [Dry Run (Preview Changes)](#dry-run-preview-changes)
-  - [Remove Symlinks](#remove-symlinks)
-  - [Restow (Refresh Symlinks)](#restow-refresh-symlinks)
-  - [Troubleshooting Conflicts](#troubleshooting-conflicts)
 
 ## Quick Install
 
@@ -69,12 +43,12 @@ cat <<EOF > ~/.gitconfig.local
 EOF
 ```
 
-## Key Tools
+## What's Included
 
 - **Shell**: Zsh + Oh My Zsh + Powerlevel10k
 - **Terminal**: Ghostty
 - **Terminal Multiplexer**: Zellij
-- **Editor**: Neovim, Zed
+- **Editors**: Neovim, Zed
 - **File Navigation**: eza, yazi, zoxide, fd
 - **Text & Viewers**: bat, glow, chroma, jq
 - **System Monitoring**: btop, htop, dust, duf, fastfetch
@@ -82,153 +56,42 @@ EOF
 - **History & Docs**: atuin, tealdeer
 - **DevOps**: k9s, kubectl, helm
 - **Launcher**: Rofi (Linux), Raycast (macOS)
-- **Utilities**: tokei, witr
 
-> **AI Coding Agents**: See [ai_agent_dotfiles](https://github.com/mfmezger/ai_agent_dotfiles) for Claude Code and OpenCode configurations.
-
-## Structure
+## Repository Structure
 
 ```bash
 ~/dotfiles/
-├── zsh/                    # Zsh configuration (.zshrc, .p10k.zsh)
-├── nvim/                   # Neovim configuration
-├── ghostty/                # Ghostty terminal config
-├── zellij/                 # Zellij terminal multiplexer config
-├── ekphos/                 # Ekphos notes app config
-├── git/                    # Git configuration (.gitconfig)
-├── yazi/                   # Yazi file manager
-├── zed/                    # Zed editor config
-├── hypr/                   # Hyprland configuration (CachyOS/Linux)
-├── waybar/                 # Waybar top bar (Hyprland/Linux)
-├── screenlayout/           # Screen layout scripts (Linux)
-├── scripts/                # Utility scripts
-├── Brewfile                # macOS packages (work)
-├── Brewfile.personal       # macOS packages (personal)
-├── install_mac.sh          # macOS installer
-├── install_linux.sh        # Arch Linux installer
+├── zsh/                     # Zsh configuration (.zshrc, .p10k.zsh)
+├── nvim/                    # Neovim configuration
+├── ghostty/                 # Ghostty terminal config
+├── kitty/                   # Kitty terminal config
+├── zellij/                  # Zellij configuration
+├── ekphos/                  # Ekphos notes app config
+├── git/                     # Git configuration (.gitconfig)
+├── yazi/                    # Yazi file manager
+├── zed/                     # Zed editor config
+├── hypr/                    # Hyprland configuration (Linux)
+├── waybar/                  # Waybar configuration (Linux)
+├── rofi/                    # Rofi launcher config (Linux)
+├── gtk/                     # GTK theming/config (Linux)
+├── screenlayout/            # Screen layout scripts (Linux)
+├── scripts/                 # Utility scripts
+├── Brewfile                 # macOS packages
+├── Brewfile.personal        # macOS personal packages
+├── Brewfile.minimal         # Minimal macOS package set
+├── install_mac.sh           # macOS installer
+├── install_linux.sh         # Arch Linux installer
 └── install_ubuntu_server.sh # Ubuntu terminal setup
 ```
 
-> **Note**: AI coding agent configurations (Claude Code, OpenCode) are managed in a separate repository: [ai_agent_dotfiles](https://github.com/mfmezger/ai_agent_dotfiles). This keeps AI tool configs separate from general development dotfiles.
+## Reference Docs
 
-## Shortcuts
+- [docs/shortcuts.md](docs/shortcuts.md) — shell abbreviations, aliases, and Zellij shortcuts
+- [docs/stow.md](docs/stow.md) — GNU Stow usage, package mapping, and conflict handling
 
-Shell abbreviations defined in `.zshrc` (type and press space to expand):
+## Stow Quick Start
 
-### Zellij
-
-Most-used Zellij shortcuts:
-
-| Shortcut | Action |
-| -------- | ------ |
-| `Alt+n`  | Open a new pane |
-| `Alt+s`  | Open a stacked split |
-| `Alt+h`  | Move focus left |
-| `Alt+j`  | Move focus down |
-| `Alt+k`  | Move focus up |
-| `Alt+l`  | Move focus right |
-
-### Basic
-
-| Shortcut | Expands To       |
-| -------- | ---------------- |
-| `e`      | `exit`           |
-| `v`      | `$EDITOR` (nvim) |
-| `c`      | `clear`          |
-| `g`      | `git`            |
-| `d`      | `docker`         |
-| `k`      | `kubectl`        |
-| `md`     | `ekphos`         |
-| `pbcopy` | Copy to clipboard (Linux) |
-| `pbpaste`| Paste from clipboard (Linux) |
-
-### Python / UV
-
-| Shortcut | Expands To                      |
-| -------- | ------------------------------- |
-| `av`     | `. .venv/bin/activate`          |
-| `us`     | `uv sync`                       |
-| `pt`     | Run pytest with coverage report |
-
-### Git
-
-| Shortcut | Expands To                      |
-| -------- | ------------------------------- |
-| `ga`     | `git add -A`                    |
-| `gs`     | `git status`                    |
-| `gd`     | `git diff`                      |
-| `gg`     | `git add . && git commit -m`    |
-| `gl`     | `git log --oneline -10`          |
-| `gp`     | `git push`                      |
-| `gpl`    | `git pull`                      |
-| `gc`     | `git checkout`                  |
-| `gcb`    | `git checkout -b`               |
-| `pcr`    | `pre-commit run --all-files`    |
-| `pcu`    | `pre-commit autoupdate`         |
-| `init`   | `pre-commit install && cz init` |
-
-### Kubernetes
-
-| Shortcut | Expands To                      |
-| -------- | ------------------------------- |
-| `k`      | `kubectl`                       |
-| `kgp`    | `kubectl get pods`              |
-| `tt`     | `tilt down; tilt up`            |
-
-### Docker
-
-| Shortcut | Expands To                     |
-| -------- | ------------------------------ |
-| `dcb`    | `docker compose build`         |
-| `dcu`    | `docker compose up`            |
-| `dcub`   | `docker compose up --build`    |
-| `dd`     | `docker compose up --build -d` |
-| `dl`     | `docker compose logs -f -t`    |
-| `dc`     | `docker compose`               |
-
-### System Update
-
-| Shortcut | Description                                                 |
-| -------- | ----------------------------------------------------------- |
-| `uu`     | Update all packages (Homebrew on macOS, pacman/yay on Arch) |
-
-### File Listing (eza)
-
-| Shortcut | Expands To                                  |
-| -------- | ------------------------------------------- |
-| `ls`     | `eza -1 -a --icons --group-directories-first` |
-| `l`      | `eza -lah --icons --group-directories-first` |
-| `ll`     | `eza -lah --icons --group-directories-first` |
-| `lt`     | `eza --tree --level 2`                     |
-| `lg`     | `eza -lah --git --icons --group-directories-first` |
-| `cat`    | `bat` (syntax-highlighted cat)             |
-
----
-
-## Stow Usage
-
-This repo uses [GNU Stow](https://www.gnu.org/software/stow/) to symlink configs to your home directory.
-
-### Stow Packages
-
-| Package        | Creates Symlinks          |
-| -------------- | ------------------------- |
-| `zsh`          | `~/.zshrc`, `~/.p10k.zsh` |
-| `git`          | `~/.gitconfig`            |
-| `nvim`         | `~/.config/nvim`          |
-| `ghostty`      | `~/.config/ghostty`       |
-| `zellij`       | `~/.config/zellij`        |
-| `ekphos`       | `~/.config/ekphos`        |
-| `yazi`         | `~/.config/yazi`          |
-| `zed`          | `~/.config/zed`           |
-| `hypr`         | `~/.config/hypr`          |
-| `dunst`        | `~/.config/dunst`         |
-| `waybar`       | `~/.config/waybar`        |
-| `screenlayout` | `~/.screenlayout`         |
-
-
-
-### Apply Configs
+This repo uses [GNU Stow](https://www.gnu.org/software/stow/) to symlink configs into your home directory.
 
 ```bash
 cd ~/dotfiles
@@ -243,40 +106,14 @@ stow zsh nvim yazi zellij git ghostty ekphos zed dunst hypr waybar rofi gtk
 stow zsh git nvim zellij ekphos
 ```
 
-> **After installing main dotfiles**, set up AI agent configs from the separate repository.
-> ```bash
-> git clone https://github.com/mfmezger/ai_agent_dotfiles.git ~/ai_agent_dotfiles
-> cd ~/ai_agent_dotfiles
-> ./install.sh
-> ```
+For dry runs, unstow/restow commands, package details, and conflict troubleshooting, see [docs/stow.md](docs/stow.md).
 
-### Dry Run (Preview Changes)
+## Related Repositories
+
+After installing the main dotfiles, set up AI agent configs from the separate repository if you use them:
 
 ```bash
-stow -n zsh  # Shows what would happen without making changes
-```
-
-### Remove Symlinks
-
-```bash
-stow -D zsh  # Unstow a package
-```
-
-### Restow (Refresh Symlinks)
-
-```bash
-stow -R zsh  # Useful after adding new files to a package
-```
-
-### Troubleshooting Conflicts
-
-If stow reports conflicts, you likely have existing files that aren't symlinks:
-
-```bash
-# Backup and remove conflicting files
-mv ~/.zshrc ~/.zshrc.backup
-mv ~/.gitconfig ~/.gitconfig.backup
-
-# Then stow again
-stow zsh git
+git clone https://github.com/mfmezger/ai_agent_dotfiles.git ~/ai_agent_dotfiles
+cd ~/ai_agent_dotfiles
+./install.sh
 ```

--- a/docs/shortcuts.md
+++ b/docs/shortcuts.md
@@ -1,0 +1,141 @@
+# Shortcuts and Shell Workflow
+
+Most command shortcuts in this repo are defined in [`zsh/.zshrc`](../zsh/.zshrc) using `zsh-abbr`.
+
+## How abbreviations work
+
+Type the abbreviation and press space to expand it.
+
+Example:
+
+- typing `gs` + space becomes `git status`
+- typing `av` + space becomes `. .venv/bin/activate`
+
+For the source of truth, see:
+
+- [`zsh/.zshrc`](../zsh/.zshrc)
+- [`zellij/.config/zellij/config.kdl`](../zellij/.config/zellij/config.kdl)
+
+## Basic Shell
+
+| Shortcut | Expands To |
+| -------- | ---------- |
+| `e` | `exit` |
+| `v` | `$EDITOR` |
+| `c` | `clear` |
+| `g` | `git` |
+| `d` | `docker` |
+| `dc` | `docker compose` |
+| `k` | `kubectl` |
+| `md` | `ekphos` |
+| `ff` | `fastfetch` |
+| `oc` | `opencode` |
+
+## Python / UV
+
+| Shortcut | Expands To |
+| -------- | ---------- |
+| `av` | `. .venv/bin/activate` |
+| `us` | `uv sync` |
+| `pt` | `uv run coverage run -m pytest -o log_cli=true -vvv tests && uv run coverage report && uv run coverage html` |
+
+## Git
+
+| Shortcut | Expands To |
+| -------- | ---------- |
+| `init` | `pre-commit install && cz init` |
+| `ga` | `git add -A` |
+| `gs` | `git status` |
+| `gd` | `git diff` |
+| `gl` | `git log --oneline -10` |
+| `gg` | `git add -A && git commit -m` |
+| `gcm` | `git commit -m` |
+| `gp` | `git push` |
+| `gpl` | `git pull` |
+| `gc` | `git checkout` |
+| `gcb` | `git checkout -b` |
+| `pcr` | `pre-commit run --all-files` |
+| `pcu` | `pre-commit autoupdate` |
+
+## File Listing and Viewing
+
+| Shortcut | Expands To |
+| -------- | ---------- |
+| `ls` | `eza -1 -a --icons --group-directories-first` |
+| `l` | `eza -lah --icons --group-directories-first` |
+| `ll` | `eza -lah --icons --group-directories-first` |
+| `lt` | `eza --tree --level 2` |
+| `tree` | `eza --tree` |
+| `lg` | `eza -lah --git --icons --group-directories-first` |
+| `cat` | `bat` |
+
+## Docker
+
+| Shortcut | Expands To |
+| -------- | ---------- |
+| `dcb` | `docker compose build` |
+| `dcu` | `docker compose up` |
+| `dcub` | `docker compose up --build` |
+| `dd` | `docker compose up --build -d` |
+| `dl` | `docker compose logs -f -t` |
+
+## Kubernetes
+
+| Shortcut | Expands To |
+| -------- | ---------- |
+| `kgp` | `kubectl get pods` |
+| `tt` | `tilt down; tilt up` |
+
+## System Update
+
+Preferred command:
+
+| Shortcut | Expands To |
+| -------- | ---------- |
+| `update` | macOS: `brew update && brew upgrade && brew cu -f -a && tldr --update && omz update` |
+| `update` | Linux: `paru -Syyu --noconfirm && tldr --update && omz update` |
+
+Legacy compatibility:
+
+| Command | Notes |
+| ------- | ----- |
+| `uu` | Still works, but prints a deprecation warning and then runs `update` |
+
+## Platform-Specific Commands
+
+### Linux only
+
+| Command | Behavior |
+| ------- | -------- |
+| `pbcopy` | Alias to `xclip -selection clipboard` |
+| `pbpaste` | Alias to `xclip -selection clipboard -o` |
+| `nvitop` | Expands to `uvx nvitop` |
+| `audio` | Expands to `pavucontrol` |
+| `zed` | Alias to `zeditor` |
+
+## Zellij Quick Reference
+
+Most-used Zellij shortcuts from [`config.kdl`](../zellij/.config/zellij/config.kdl):
+
+| Shortcut | Action |
+| -------- | ------ |
+| `Alt+n` | Open a new pane |
+| `Alt+s` | Open a stacked pane |
+| `Alt+h` | Move focus left |
+| `Alt+j` | Move focus down |
+| `Alt+k` | Move focus up |
+| `Alt+l` | Move focus right |
+| `Alt+o` | Previous tab |
+| `Alt+p` | Next tab |
+| `Alt+t` | New tab |
+| `Alt+i` | Move tab left |
+| `Alt+f` | Toggle floating panes |
+| `Ctrl+p` | Enter pane mode |
+| `Ctrl+t` | Enter tab mode |
+| `Ctrl+n` | Enter resize mode |
+| `Ctrl+h` | Enter move mode |
+| `Ctrl+s` | Enter scroll mode |
+| `Ctrl+o` | Enter session mode |
+| `Ctrl+g` | Lock Zellij keybindings; press again to return |
+
+If you want to explore more bindings, the config file is the canonical reference.

--- a/docs/stow.md
+++ b/docs/stow.md
@@ -1,0 +1,100 @@
+# GNU Stow Usage
+
+This repo uses [GNU Stow](https://www.gnu.org/software/stow/) to manage symlinks from the package directories in this repository into your home directory.
+
+## Common Packages
+
+| Package | Creates Symlinks |
+| ------- | ---------------- |
+| `zsh` | `~/.zshrc`, `~/.p10k.zsh` |
+| `git` | `~/.gitconfig` |
+| `nvim` | `~/.config/nvim` |
+| `ghostty` | `~/.config/ghostty` |
+| `zellij` | `~/.config/zellij` |
+| `ekphos` | `~/.config/ekphos` |
+| `yazi` | `~/.config/yazi` |
+| `zed` | `~/.config/zed` |
+| `dunst` | `~/.config/dunst` |
+| `hypr` | `~/.config/hypr` |
+| `waybar` | `~/.config/waybar` |
+| `rofi` | `~/.config/rofi` |
+| `gtk` | `~/.config/gtk-3.0`, `~/.gtkrc-2.0` |
+| `screenlayout` | `~/.screenlayout` |
+
+## Apply Configs
+
+Run `stow` from the repo root:
+
+```bash
+cd ~/dotfiles
+```
+
+### macOS
+
+```bash
+stow zsh git nvim ghostty zellij ekphos yazi zed
+```
+
+### Arch Linux / CachyOS
+
+```bash
+stow zsh nvim yazi zellij git ghostty ekphos zed dunst hypr waybar rofi gtk
+```
+
+### Ubuntu (minimal)
+
+```bash
+stow zsh git nvim zellij ekphos
+```
+
+## Useful Commands
+
+### Dry run
+
+Preview changes before creating symlinks:
+
+```bash
+stow -n zsh
+```
+
+### Remove symlinks
+
+Unstow a package:
+
+```bash
+stow -D zsh
+```
+
+### Restow
+
+Refresh symlinks after adding or moving files in a package:
+
+```bash
+stow -R zsh
+```
+
+## Troubleshooting Conflicts
+
+If Stow reports a conflict, a target file probably already exists and is not a symlink managed by Stow.
+
+Example:
+
+```bash
+mv ~/.zshrc ~/.zshrc.backup
+mv ~/.gitconfig ~/.gitconfig.backup
+
+stow zsh git
+```
+
+## Practical Tips
+
+- Run `stow` from `~/dotfiles`.
+- Start with a dry run when applying a package for the first time.
+- Use `stow -R <package>` after adding new files to an existing package.
+- If something conflicts, back it up before stowing.
+- Apply packages in small batches if you're debugging a setup issue.
+
+## Related Docs
+
+- [README.md](../README.md)
+- [shortcuts.md](shortcuts.md)


### PR DESCRIPTION
## Summary
- simplify the README into a shorter project landing page
- move shell shortcuts and Zellij keybindings into `docs/shortcuts.md`
- move GNU Stow usage and troubleshooting into `docs/stow.md`

## Testing
- not run (documentation only)