### PR TITLE
docs(readme): add macOS Brewfile profile comparison

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,9 +41,32 @@ cd ~/dotfiles
 
 ### macOS
 
+macOS installation uses Homebrew and has three profiles depending on your use case:
+
+| Profile        | File               | What it includes                                      |
+| -------------- | ------------------ | ----------------------------------------------------- |
+| **All**        | `Brewfile`         | Full work setup (DevOps, cloud tools, productivity)  |
+| **Minimal**    | `Brewfile.minimal` | Essentials only (zsh, git, eza, yazi, shell tools)   |
+| **Personal**   | `Brewfile.personal`| Personal apps (AI coding tools, messaging, media)     |
+
 ```bash
+# Run the base installer (sets up Homebrew, zsh, and stow)
 ./install_mac.sh
+
+# Then apply dotfiles with stow
+stow zsh git nvim ghostty zellij ekphos yazi zed
+
+# Install all work packages (DevOps, cloud, productivity)
+brew bundle --file=Brewfile
+
+# OR install only the minimal shell essentials
+brew bundle --file=Brewfile.minimal
+
+# Personal packages (AI coding agents, messaging, media)
+brew bundle --file=Brewfile.personal
 ```
+
+You can combine profiles — for example, start with `Brewfile.minimal` and add `Brewfile.personal` on top for personal machines.
 
 ### Arch Linux / CachyOS
 

--- a/README.md
+++ b/README.md
@@ -41,32 +41,19 @@ cd ~/dotfiles
 
 ### macOS
 
-macOS installation uses Homebrew and has three profiles depending on your use case:
-
-| Profile        | File               | What it includes                                      |
-| -------------- | ------------------ | ----------------------------------------------------- |
-| **All**        | `Brewfile`         | Full work setup (DevOps, cloud tools, productivity)  |
-| **Minimal**    | `Brewfile.minimal` | Essentials only (zsh, git, eza, yazi, shell tools)   |
-| **Personal**   | `Brewfile.personal`| Personal apps (AI coding tools, messaging, media)     |
+The installer is interactive — it prompts for minimal vs. full install and personal packages:
 
 ```bash
-# Run the base installer (sets up Homebrew, zsh, and stow)
 ./install_mac.sh
-
-# Then apply dotfiles with stow
-stow zsh git nvim ghostty zellij ekphos yazi zed
-
-# Install all work packages (DevOps, cloud, productivity)
-brew bundle --file=Brewfile
-
-# OR install only the minimal shell essentials
-brew bundle --file=Brewfile.minimal
-
-# Personal packages (AI coding agents, messaging, media)
-brew bundle --file=Brewfile.personal
 ```
 
-You can combine profiles — for example, start with `Brewfile.minimal` and add `Brewfile.personal` on top for personal machines.
+**Brewfile profiles:**
+
+| Profile | File | When to use |
+| --- | --- | --- |
+| Full | `Brewfile` | Work machine with DevOps/cloud tools |
+| Minimal | `Brewfile.minimal` | Shell essentials only (zsh, git, eza, yazi, zellij) |
+| Personal | `Brewfile.personal` | AI coding agents, messaging, media (add on top) |
 
 ### Arch Linux / CachyOS
 


### PR DESCRIPTION
Adds a macOS installation section that explains the three Brewfile profiles:

- **Brewfile** — full work setup (DevOps, cloud, productivity)
- **Brewfile.minimal** — essentials only (zsh, git, eza, yazi, shell tools)
- **Brewfile.personal** — personal apps (AI coding tools, messaging, media)

Also documents how to use stow and how profiles can be combined.