### PR TITLE
fix(zsh): remove git-hubflow plugin

### DIFF
--- a/zsh/.zshrc
+++ b/zsh/.zshrc
@@ -23,7 +23,6 @@ fi
 plugins=(
     # Git
     git
-    git-hubflow
     gh
     # Docker
     docker


### PR DESCRIPTION
The git-hubflow plugin implements the GitFlow branching model which is not the standard workflow — GitHub Flow prevails at most companies. Removes unnecessary completions loading on every shell startup.