### PR TITLE
fix(zsh): guard distro nvm fallback

### DIFF
--- a/zsh/.zshrc
+++ b/zsh/.zshrc
@@ -292,7 +292,6 @@ fi
 export NVM_DIR="$HOME/.nvm"
 [ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"  # This loads nvm
 [ -s "$NVM_DIR/bash_completion" ] && \. "$NVM_DIR/bash_completion"  # This loads nvm bash_completion
-source /usr/share/nvm/init-nvm.sh
 
 export PATH="/Applications/PyCharm.app/Contents/MacOS:$PATH"
 

--- a/zsh/.zshrc
+++ b/zsh/.zshrc
@@ -292,6 +292,9 @@ fi
 export NVM_DIR="$HOME/.nvm"
 [ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"  # This loads nvm
 [ -s "$NVM_DIR/bash_completion" ] && \. "$NVM_DIR/bash_completion"  # This loads nvm bash_completion
+if ! command -v nvm >/dev/null 2>&1 && [ -s "/usr/share/nvm/init-nvm.sh" ]; then
+    . "/usr/share/nvm/init-nvm.sh"
+fi
 
 export PATH="/Applications/PyCharm.app/Contents/MacOS:$PATH"
 

--- a/zsh/.zshrc
+++ b/zsh/.zshrc
@@ -293,7 +293,7 @@ export NVM_DIR="$HOME/.nvm"
 [ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"  # This loads nvm
 [ -s "$NVM_DIR/bash_completion" ] && \. "$NVM_DIR/bash_completion"  # This loads nvm bash_completion
 if ! command -v nvm >/dev/null 2>&1 && [ -s "/usr/share/nvm/init-nvm.sh" ]; then
-    . "/usr/share/nvm/init-nvm.sh"
+    \. "/usr/share/nvm/init-nvm.sh"
 fi
 
 export PATH="/Applications/PyCharm.app/Contents/MacOS:$PATH"


### PR DESCRIPTION
Avoid sourcing the distro NVM init script unconditionally.

The normal `$HOME/.nvm/nvm.sh` and bash completion files are still loaded first. `/usr/share/nvm/init-nvm.sh` is kept as an Arch/system-package fallback, but only sourced when `nvm` is not already available and the fallback file exists.

This prevents shell startup errors on systems without the distro path and avoids double-loading NVM when the user-local install already initialized it.
