### PR TITLE
fix(install): remove duplicate git clones of zsh plugins

### DIFF
--- a/install_linux.sh
+++ b/install_linux.sh
@@ -193,20 +193,6 @@ fi
 
 ZSH_CUSTOM="$HOME/.oh-my-zsh/custom"
 
-echo ">>> Installing zsh-autosuggestions <<<"
-if [ ! -d "$ZSH_CUSTOM/plugins/zsh-autosuggestions" ]; then
-    git clone https://github.com/zsh-users/zsh-autosuggestions "$ZSH_CUSTOM/plugins/zsh-autosuggestions"
-else
-    echo ">>> zsh-autosuggestions already installed <<<"
-fi
-
-echo ">>> Installing zsh-syntax-highlighting <<<"
-if [ ! -d "$ZSH_CUSTOM/plugins/zsh-syntax-highlighting" ]; then
-    git clone https://github.com/zsh-users/zsh-syntax-highlighting.git "$ZSH_CUSTOM/plugins/zsh-syntax-highlighting"
-else
-    echo ">>> zsh-syntax-highlighting already installed <<<"
-fi
-
 echo ">>> Installing zsh-autosuggestions-abbreviations-strategy <<<"
 if [ ! -d "$HOME/.local/share/zsh-autosuggestions-abbreviations-strategy" ]; then
     git clone https://github.com/olets/zsh-autosuggestions-abbreviations-strategy.git \

--- a/install_mac.sh
+++ b/install_mac.sh
@@ -94,21 +94,7 @@ else
     echo ">>> Powerlevel10k already installed <<<"
 fi
 
-echo ">>> Installing zsh-autosuggestions <<<"
-if [ ! -d "$ZSH_CUSTOM/plugins/zsh-autosuggestions" ]; then
-    git clone https://github.com/zsh-users/zsh-autosuggestions "$ZSH_CUSTOM/plugins/zsh-autosuggestions"
-else
-    echo ">>> zsh-autosuggestions already installed <<<"
-fi
-
-echo ">>> Installing zsh-syntax-highlighting <<<"
-if [ ! -d "$ZSH_CUSTOM/plugins/zsh-syntax-highlighting" ]; then
-    git clone https://github.com/zsh-users/zsh-syntax-highlighting.git "$ZSH_CUSTOM/plugins/zsh-syntax-highlighting"
-else
-    echo ">>> zsh-syntax-highlighting already installed <<<"
-fi
-
-# 7. Generate Static Completions (Pre-cached for faster shell startup)
+# 7. Generate Static Completions
 echo ">>> Generating shell completions <<<"
 COMPLETIONS_DIR="$HOME/.local/share/zsh/completions"
 mkdir -p "$COMPLETIONS_DIR"


### PR DESCRIPTION
Both install_mac.sh and install_linux.sh were manually git cloning zsh-autosuggestions and zsh-syntax-highlighting into $ZSH_CUSTOM/plugins/, but these plugins are already managed by Oh My Zsh's plugin system and referenced in plugins=() in .zshrc. The duplicate clones created redundant copies outside OMZ's control, risking version skew. OMZ loads them from its own managed location, so the manual clones are unnecessary.