### PR TITLE
fix(zsh): guard completions.zsh source with -f check

### DIFF
--- a/zsh/.zshrc
+++ b/zsh/.zshrc
@@ -188,7 +188,9 @@ elif [[ "$OSTYPE" == "linux-gnu"* ]]; then
 fi
 
 # Pre-cached completions (moved to separate file for cleaner .zshrc)
-source $HOME/dotfiles/zsh/completions.zsh
+if [[ -f "$HOME/dotfiles/zsh/completions.zsh" ]]; then
+    source "$HOME/dotfiles/zsh/completions.zsh"
+fi
 
 # Normalize trailing slashes for zoxide-backed `cd` queries.
 # Without this, `cd project/` falls through to `zoxide query "project/"`,

--- a/zsh/.zshrc
+++ b/zsh/.zshrc
@@ -55,7 +55,7 @@ fi
 
 # OPTIMIZATION: Manually handle completion initialization
 # Moved ugly logic to separate file to keep .zshrc clean
-if [[ -f "$HOME/dotfiles/zsh/fast_init.zsh" ]]; then
+if [[ -r "$HOME/dotfiles/zsh/fast_init.zsh" ]]; then
     source "$HOME/dotfiles/zsh/fast_init.zsh"
 fi
 
@@ -190,7 +190,7 @@ elif [[ "$OSTYPE" == "linux-gnu"* ]]; then
 fi
 
 # Pre-cached completions (moved to separate file for cleaner .zshrc)
-if [[ -f "$HOME/dotfiles/zsh/completions.zsh" ]]; then
+if [[ -r "$HOME/dotfiles/zsh/completions.zsh" ]]; then
     source "$HOME/dotfiles/zsh/completions.zsh"
 fi
 

--- a/zsh/.zshrc
+++ b/zsh/.zshrc
@@ -55,7 +55,9 @@ fi
 
 # OPTIMIZATION: Manually handle completion initialization
 # Moved ugly logic to separate file to keep .zshrc clean
-source $HOME/dotfiles/zsh/fast_init.zsh
+if [[ -f "$HOME/dotfiles/zsh/fast_init.zsh" ]]; then
+    source "$HOME/dotfiles/zsh/fast_init.zsh"
+fi
 
 source $ZSH/oh-my-zsh.sh
 


### PR DESCRIPTION
On minimal installs or before stow runs, completions.zsh may not exist. Source it conditionally to avoid errors on shell startup.