### PR TITLE
ci(shell-lint): add GitHub Actions workflow for shell scripts

### DIFF
--- a/.github/workflows/shell-lint.yml
+++ b/.github/workflows/shell-lint.yml
@@ -1,0 +1,52 @@
+name: Shell Lint
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "**.sh"
+      - ".github/workflows/shell-lint.yml"
+  pull_request:
+    paths:
+      - "**.sh"
+      - ".github/workflows/shell-lint.yml"
+
+jobs:
+  shellcheck:
+    name: shellcheck
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Run shellcheck
+        uses: ludeeus/action-shellcheck@2.0.0
+        with:
+          shellcheckflags: --severity=error --exclude=SC1091,SC2086
+
+  shfmt:
+    name: shfmt
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install shfmt
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y shfmt
+
+      - name: Check formatting
+        run: |
+          set -e
+          unformatted=$(shfmt -l -sr -i 4 \
+            install_mac.sh \
+            install_linux.sh \
+            install_ubuntu_server.sh \
+            scripts/*.sh \
+            scripts/**/*.sh 2>/dev/null || true)
+          if [ -n "$unformatted" ]; then
+            echo "Unformatted files:"
+            echo "$unformatted"
+            echo ""
+            echo "Run 'shfmt -w -sr -i 4 <file>' to fix."
+            exit 1
+          fi

--- a/.github/workflows/shell-lint.yml
+++ b/.github/workflows/shell-lint.yml
@@ -4,12 +4,16 @@ on:
   push:
     branches: [main]
     paths:
-      - "**.sh"
+      - "*.sh"
+      - "**/*.sh"
       - ".github/workflows/shell-lint.yml"
   pull_request:
     paths:
-      - "**.sh"
+      - "*.sh"
+      - "**/*.sh"
       - ".github/workflows/shell-lint.yml"
+
+permissions: {}
 
 jobs:
   shellcheck:
@@ -18,10 +22,17 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - name: Install shellcheck
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y shellcheck
+
       - name: Run shellcheck
-        uses: ludeeus/action-shellcheck@2.0.0
-        with:
-          shellcheckflags: --severity=error --exclude=SC1091,SC2086
+        shell: bash
+        run: |
+          set -euo pipefail
+          find . -path ./.git -prune -o -type f -name "*.sh" -print0 \
+            | xargs -0 -r shellcheck -S error -e SC1091,SC2086
 
   shfmt:
     name: shfmt
@@ -35,18 +46,8 @@ jobs:
           sudo apt-get install -y shfmt
 
       - name: Check formatting
+        shell: bash
         run: |
-          set -e
-          unformatted=$(shfmt -l -sr -i 4 \
-            install_mac.sh \
-            install_linux.sh \
-            install_ubuntu_server.sh \
-            scripts/*.sh \
-            scripts/**/*.sh 2>/dev/null || true)
-          if [ -n "$unformatted" ]; then
-            echo "Unformatted files:"
-            echo "$unformatted"
-            echo ""
-            echo "Run 'shfmt -w -sr -i 4 <file>' to fix."
-            exit 1
-          fi
+          set -euo pipefail
+          find . -path ./.git -prune -o -type f -name "*.sh" -print0 \
+            | xargs -0 -r shfmt -d -sr -i 4


### PR DESCRIPTION
Adds a GitHub Actions workflow that:
- Runs  on all shell scripts (install_mac.sh, install_linux.sh, install_ubuntu_server.sh, scripts/)
- Runs  to check formatting (4-space indent, space after shebang)
- Triggers on push to main and on PRs when .sh files change
- Does not block merges on SC1091 (can't follow non-constant sources) or SC2086 (word splitting)