### PR TITLE
fix(zsh): default gwt base to main

### DIFF
--- a/zsh/.zshrc
+++ b/zsh/.zshrc
@@ -224,13 +224,14 @@ function gwt() {
     fi
 
     local name="$1"
+    local default_target="${GWT_BASE:-main}"
     if [[ -z "$name" ]]; then
         echo "Usage: gwt <name> [target]"
-        echo "Default target: \\$GWT_BASE or main"
+        echo "Default target: $default_target"
         return 1
     fi
 
-    local target="${2:-${GWT_BASE:-main}}"
+    local target="${2:-$default_target}"
     local worktree_dir="/tmp/worktrees/$name"
 
     # Ensure parent directory exists

--- a/zsh/.zshrc
+++ b/zsh/.zshrc
@@ -225,11 +225,12 @@ function gwt() {
 
     local name="$1"
     if [[ -z "$name" ]]; then
-        echo "Usage: gwt <name>"
+        echo "Usage: gwt <name> [target]"
+        echo "Default target: \\$GWT_BASE or main"
         return 1
     fi
 
-    local target="HEAD"
+    local target="${2:-${GWT_BASE:-main}}"
     local worktree_dir="/tmp/worktrees/$name"
 
     # Ensure parent directory exists


### PR DESCRIPTION
## Summary
- default `gwt` to `main` instead of the current `HEAD`
- allow passing an explicit target as the second argument
- allow overriding the default base with `GWT_BASE`

## Verification
- `zsh -n zsh/.zshrc`