### PR TITLE
fix(shell): format scripts for shfmt

### DIFF
--- a/install_linux.sh
+++ b/install_linux.sh
@@ -71,7 +71,7 @@ POWERLEVEL10K_INSTALLED_FROM_REPO=0
 if pacman -Q zsh-theme-powerlevel10k &> /dev/null; then
     echo ">>> zsh-theme-powerlevel10k already installed <<<"
     POWERLEVEL10K_INSTALLED_FROM_REPO=1
-elif sudo pacman -Si zsh-theme-powerlevel10k &> /dev/null; then
+elif pacman -Si zsh-theme-powerlevel10k &> /dev/null; then
     echo ">>> Installing zsh-theme-powerlevel10k from pacman <<<"
     sudo pacman -S --needed --noconfirm zsh-theme-powerlevel10k
     POWERLEVEL10K_INSTALLED_FROM_REPO=1

--- a/install_linux.sh
+++ b/install_linux.sh
@@ -68,10 +68,10 @@ sudo pacman -S --needed --noconfirm \
 
 # Install the packaged Powerlevel10k when available to avoid AUR conflicts
 POWERLEVEL10K_INSTALLED_FROM_REPO=0
-if pacman -Q zsh-theme-powerlevel10k &>/dev/null; then
+if pacman -Q zsh-theme-powerlevel10k &> /dev/null; then
     echo ">>> zsh-theme-powerlevel10k already installed <<<"
     POWERLEVEL10K_INSTALLED_FROM_REPO=1
-elif sudo pacman -Si zsh-theme-powerlevel10k &>/dev/null; then
+elif sudo pacman -Si zsh-theme-powerlevel10k &> /dev/null; then
     echo ">>> Installing zsh-theme-powerlevel10k from pacman <<<"
     sudo pacman -S --needed --noconfirm zsh-theme-powerlevel10k
     POWERLEVEL10K_INSTALLED_FROM_REPO=1
@@ -83,9 +83,9 @@ fi
 echo ">>> Installing AUR packages <<<"
 
 # Prefer paru on CachyOS, fall back to yay on other Arch-based systems
-if command -v paru &>/dev/null; then
+if command -v paru &> /dev/null; then
     AUR_HELPER="paru"
-elif command -v yay &>/dev/null; then
+elif command -v yay &> /dev/null; then
     AUR_HELPER="yay"
 else
     echo ">>> Installing paru AUR helper <<<"
@@ -149,7 +149,7 @@ if [[ $REPLY =~ ^[Yy]$ ]]; then
     else
         echo ">>> Installing NVIDIA drivers via distro tooling when available <<<"
         # nvidia-inst exists on some Arch-based distros and picks a suitable stack.
-        if command -v nvidia-inst &>/dev/null; then
+        if command -v nvidia-inst &> /dev/null; then
             nvidia-inst
         else
             echo ">>> nvidia-inst not found, installing generic nvidia packages <<<"
@@ -219,7 +219,7 @@ fi
 # 7. Install Python Tools (uv & commitizen)
 # ==============================================================================
 echo ">>> Installing uv <<<"
-if ! command -v uv &>/dev/null; then
+if ! command -v uv &> /dev/null; then
     curl -LsSf https://astral.sh/uv/install.sh | sh
 else
     echo ">>> uv already installed <<<"
@@ -232,7 +232,7 @@ export PATH="$HOME/.local/bin:$PATH"
 # 8. Install Rust Toolchain (rustup)
 # ==============================================================================
 echo ">>> Installing rustup <<<"
-if ! command -v rustup &>/dev/null; then
+if ! command -v rustup &> /dev/null; then
     curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --no-modify-path
 else
     echo ">>> rustup already installed <<<"
@@ -242,7 +242,7 @@ if [ -f "$HOME/.cargo/env" ]; then
     . "$HOME/.cargo/env"
 fi
 
-if ! cargo --version &>/dev/null; then
+if ! cargo --version &> /dev/null; then
     echo ">>> Configuring default Rust toolchain (stable) <<<"
     rustup default stable
 else
@@ -260,16 +260,16 @@ COMPLETIONS_DIR="$HOME/.local/share/zsh/completions"
 mkdir -p "$COMPLETIONS_DIR"
 
 # Generate uv completions
-if command -v uv &>/dev/null; then
+if command -v uv &> /dev/null; then
     echo ">>> Generating uv/uvx completions <<<"
-    uv generate-shell-completion zsh >"$COMPLETIONS_DIR/_uv"
-    uvx --generate-shell-completion zsh >"$COMPLETIONS_DIR/_uvx"
+    uv generate-shell-completion zsh > "$COMPLETIONS_DIR/_uv"
+    uvx --generate-shell-completion zsh > "$COMPLETIONS_DIR/_uvx"
 fi
 
 # Generate atuin init script
-if command -v atuin &>/dev/null; then
+if command -v atuin &> /dev/null; then
     echo ">>> Generating atuin completions <<<"
-    atuin init zsh >"$COMPLETIONS_DIR/atuin-init.zsh"
+    atuin init zsh > "$COMPLETIONS_DIR/atuin-init.zsh"
     echo ">>> Importing shell history into atuin <<<"
     atuin import auto || {
         echo ">>> Warning: Failed to import shell history into atuin."
@@ -278,27 +278,27 @@ if command -v atuin &>/dev/null; then
 fi
 
 # Generate GitHub CLI completions
-if command -v gh &>/dev/null; then
+if command -v gh &> /dev/null; then
     echo ">>> Generating gh completions <<<"
-    gh completion -s zsh >"$COMPLETIONS_DIR/_gh"
+    gh completion -s zsh > "$COMPLETIONS_DIR/_gh"
 fi
 
 # Generate Docker completions
-if command -v docker &>/dev/null; then
+if command -v docker &> /dev/null; then
     echo ">>> Generating docker completions <<<"
-    docker completion zsh >"$COMPLETIONS_DIR/_docker"
+    docker completion zsh > "$COMPLETIONS_DIR/_docker"
 fi
 
 # Generate kubectl completions (if installed)
-if command -v kubectl &>/dev/null; then
+if command -v kubectl &> /dev/null; then
     echo ">>> Generating kubectl completions <<<"
-    kubectl completion zsh >"$COMPLETIONS_DIR/_kubectl"
+    kubectl completion zsh > "$COMPLETIONS_DIR/_kubectl"
 fi
 
 # Generate helm completions (if installed)
-if command -v helm &>/dev/null; then
+if command -v helm &> /dev/null; then
     echo ">>> Generating helm completions <<<"
-    helm completion zsh >"$COMPLETIONS_DIR/_helm"
+    helm completion zsh > "$COMPLETIONS_DIR/_helm"
 fi
 
 # ==============================================================================

--- a/install_mac.sh
+++ b/install_mac.sh
@@ -9,7 +9,7 @@ echo ">>> Starting Installation from $DOTFILES_DIR <<<"
 source "$DOTFILES_DIR/scripts/common.sh"
 
 # 1. Install Homebrew
-if ! command -v brew &>/dev/null; then
+if ! command -v brew &> /dev/null; then
     echo ">>> Installing Homebrew <<<"
     /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
 
@@ -47,7 +47,7 @@ fi
 
 # 3. Install Python tools (uv)
 echo ">>> Installing uv <<<"
-if ! command -v uv &>/dev/null; then
+if ! command -v uv &> /dev/null; then
     curl -LsSf https://astral.sh/uv/install.sh | sh
 else
     echo ">>> uv already installed <<<"
@@ -56,7 +56,7 @@ fi
 # 4. Install Rust toolchain (full install only)
 if [[ ! $MINIMAL_INSTALL =~ ^[Yy]$ ]]; then
     echo ">>> Installing rustup <<<"
-    if ! command -v rustup &>/dev/null; then
+    if ! command -v rustup &> /dev/null; then
         curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --no-modify-path
     else
         echo ">>> rustup already installed <<<"
@@ -66,7 +66,7 @@ if [[ ! $MINIMAL_INSTALL =~ ^[Yy]$ ]]; then
         . "$HOME/.cargo/env"
     fi
 
-    if ! cargo --version &>/dev/null; then
+    if ! cargo --version &> /dev/null; then
         echo ">>> Configuring default Rust toolchain (stable) <<<"
         rustup default stable
     else
@@ -114,16 +114,16 @@ COMPLETIONS_DIR="$HOME/.local/share/zsh/completions"
 mkdir -p "$COMPLETIONS_DIR"
 
 # Generate uv completions
-if command -v uv &>/dev/null; then
+if command -v uv &> /dev/null; then
     echo ">>> Generating uv/uvx completions <<<"
-    uv generate-shell-completion zsh >"$COMPLETIONS_DIR/_uv"
-    uvx --generate-shell-completion zsh >"$COMPLETIONS_DIR/_uvx"
+    uv generate-shell-completion zsh > "$COMPLETIONS_DIR/_uv"
+    uvx --generate-shell-completion zsh > "$COMPLETIONS_DIR/_uvx"
 fi
 
 # Generate atuin init script
-if command -v atuin &>/dev/null; then
+if command -v atuin &> /dev/null; then
     echo ">>> Generating atuin completions <<<"
-    atuin init zsh >"$COMPLETIONS_DIR/atuin-init.zsh"
+    atuin init zsh > "$COMPLETIONS_DIR/atuin-init.zsh"
     echo ">>> Importing shell history into atuin <<<"
     atuin import auto || {
         echo ">>> Warning: Failed to import shell history into atuin."
@@ -132,27 +132,27 @@ if command -v atuin &>/dev/null; then
 fi
 
 # Generate GitHub CLI completions
-if command -v gh &>/dev/null; then
+if command -v gh &> /dev/null; then
     echo ">>> Generating gh completions <<<"
-    gh completion -s zsh >"$COMPLETIONS_DIR/_gh"
+    gh completion -s zsh > "$COMPLETIONS_DIR/_gh"
 fi
 
 # Generate Docker completions (full install only)
-if [[ ! $MINIMAL_INSTALL =~ ^[Yy]$ ]] && command -v docker &>/dev/null; then
+if [[ ! $MINIMAL_INSTALL =~ ^[Yy]$ ]] && command -v docker &> /dev/null; then
     echo ">>> Generating docker completions <<<"
-    docker completion zsh >"$COMPLETIONS_DIR/_docker"
+    docker completion zsh > "$COMPLETIONS_DIR/_docker"
 fi
 
 # Generate kubectl completions (full install only)
-if [[ ! $MINIMAL_INSTALL =~ ^[Yy]$ ]] && command -v kubectl &>/dev/null; then
+if [[ ! $MINIMAL_INSTALL =~ ^[Yy]$ ]] && command -v kubectl &> /dev/null; then
     echo ">>> Generating kubectl completions <<<"
-    kubectl completion zsh >"$COMPLETIONS_DIR/_kubectl"
+    kubectl completion zsh > "$COMPLETIONS_DIR/_kubectl"
 fi
 
 # Generate helm completions (full install only)
-if [[ ! $MINIMAL_INSTALL =~ ^[Yy]$ ]] && command -v helm &>/dev/null; then
+if [[ ! $MINIMAL_INSTALL =~ ^[Yy]$ ]] && command -v helm &> /dev/null; then
     echo ">>> Generating helm completions <<<"
-    helm completion zsh >"$COMPLETIONS_DIR/_helm"
+    helm completion zsh > "$COMPLETIONS_DIR/_helm"
 fi
 
 # 8. Link Dotfiles

--- a/install_ubuntu_server.sh
+++ b/install_ubuntu_server.sh
@@ -85,7 +85,7 @@ fi
 # Install atuin (better history)
 if ! command -v atuin &> /dev/null; then
     bash <(curl https://raw.githubusercontent.com/atuinsh/atuin/main/install.sh)
-    sudo mv ~/.cargo/bin/atuin /usr/local/bin/ 2> /dev/null || true
+    sudo mv ~/.atuin/bin/atuin /usr/local/bin/ 2> /dev/null || true
 fi
 
 # Install uv (Python package manager)

--- a/install_ubuntu_server.sh
+++ b/install_ubuntu_server.sh
@@ -56,7 +56,7 @@ fi
 
 # Try to install eza via apt (available in Ubuntu 24.04+)
 echo "📦 Installing eza..."
-if sudo apt install -y rust-eza 2>/dev/null; then
+if sudo apt install -y rust-eza 2> /dev/null; then
     echo "✅ eza installed via apt"
     # Create symlink if eza binary has different name
     if [ -f /usr/bin/eza ] && [ ! -f /usr/local/bin/eza ]; then
@@ -64,7 +64,7 @@ if sudo apt install -y rust-eza 2>/dev/null; then
     fi
 else
     echo "📥 eza not available via apt, installing from binary..."
-    if ! command -v eza &>/dev/null; then
+    if ! command -v eza &> /dev/null; then
         wget -qO- https://raw.githubusercontent.com/eza-community/eza/main/deb.asc | sudo gpg --dearmor -o /etc/apt/keyrings/gierens.gpg
         echo "deb [signed-by=/etc/apt/keyrings/gierens.gpg] http://deb.gierens.de stable main" | sudo tee /etc/apt/sources.list.d/gierens.list
         sudo chmod 644 /etc/apt/keyrings/gierens.gpg /etc/apt/sources.list.d/gierens.list
@@ -77,20 +77,20 @@ fi
 echo "🔧 Installing additional tools..."
 
 # Install zoxide (smart cd)
-if ! command -v zoxide &>/dev/null; then
+if ! command -v zoxide &> /dev/null; then
     curl -sS https://raw.githubusercontent.com/ajeetdsouza/zoxide/main/install.sh | bash
     sudo mv ~/.local/bin/zoxide /usr/local/bin/
 fi
 
 # Install atuin (better history)
-if ! command -v atuin &>/dev/null; then
+if ! command -v atuin &> /dev/null; then
     bash <(curl https://raw.githubusercontent.com/atuinsh/atuin/main/install.sh)
-    sudo mv ~/.cargo/bin/atuin /usr/local/bin/ 2>/dev/null || true
+    sudo mv ~/.cargo/bin/atuin /usr/local/bin/ 2> /dev/null || true
 fi
 
 # Install uv (Python package manager)
 echo "🐍 Installing uv..."
-if ! command -v uv &>/dev/null; then
+if ! command -v uv &> /dev/null; then
     curl -LsSf https://astral.sh/uv/install.sh | sh
 fi
 
@@ -99,7 +99,7 @@ export PATH="$HOME/.local/bin:$PATH"
 
 # Install Rust toolchain via rustup
 echo "🦀 Installing rustup..."
-if ! command -v rustup &>/dev/null; then
+if ! command -v rustup &> /dev/null; then
     curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --no-modify-path
 else
     echo "✅ rustup already installed"
@@ -110,7 +110,7 @@ if [ -f "$HOME/.cargo/env" ]; then
     . "$HOME/.cargo/env"
 fi
 
-if ! cargo --version &>/dev/null; then
+if ! cargo --version &> /dev/null; then
     echo "🦀 Configuring default Rust toolchain (stable)..."
     rustup default stable
 else
@@ -119,8 +119,8 @@ fi
 
 # Install zellij terminal multiplexer
 echo "🪟 Installing zellij..."
-if ! command -v zellij &>/dev/null; then
-    if sudo apt install -y zellij 2>/dev/null; then
+if ! command -v zellij &> /dev/null; then
+    if sudo apt install -y zellij 2> /dev/null; then
         echo "✅ zellij installed via apt"
     else
         echo "📥 zellij not available via apt, installing cargo build dependencies..."
@@ -136,13 +136,13 @@ uv tool install commitizen
 
 # Install witr (weather tool)
 echo "🌤️ Installing witr..."
-if ! command -v witr &>/dev/null; then
+if ! command -v witr &> /dev/null; then
     curl -fsSL https://raw.githubusercontent.com/pranshuparmar/witr/main/install.sh | bash
 fi
 
 # Install ekphos (Markdown notes app)
 echo "📝 Installing ekphos..."
-if ! command -v ekphos &>/dev/null; then
+if ! command -v ekphos &> /dev/null; then
     cargo install ekphos
 fi
 
@@ -191,14 +191,14 @@ COMPLETIONS_DIR="$HOME/.local/share/zsh/completions"
 mkdir -p "$COMPLETIONS_DIR"
 
 # Generate uv completions
-if command -v uv &>/dev/null; then
-    uv generate-shell-completion zsh >"$COMPLETIONS_DIR/_uv"
-    uvx --generate-shell-completion zsh >"$COMPLETIONS_DIR/_uvx"
+if command -v uv &> /dev/null; then
+    uv generate-shell-completion zsh > "$COMPLETIONS_DIR/_uv"
+    uvx --generate-shell-completion zsh > "$COMPLETIONS_DIR/_uvx"
 fi
 
 # Generate atuin init script
-if command -v atuin &>/dev/null; then
-    atuin init zsh >"$COMPLETIONS_DIR/atuin-init.zsh"
+if command -v atuin &> /dev/null; then
+    atuin init zsh > "$COMPLETIONS_DIR/atuin-init.zsh"
     echo ">>> Importing shell history into atuin <<<"
     atuin import auto || {
         echo ">>> Warning: Failed to import shell history into atuin."

--- a/scripts/docker_install.sh
+++ b/scripts/docker_install.sh
@@ -4,7 +4,7 @@
 sudo apt update
 sudo apt install apt-transport-https ca-certificates curl software-properties-common -y
 curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo gpg --dearmor -o /usr/share/keyrings/docker-archive-keyring.gpg
-echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/docker-archive-keyring.gpg] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable" | sudo tee /etc/apt/sources.list.d/docker.list >/dev/null
+echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/docker-archive-keyring.gpg] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable" | sudo tee /etc/apt/sources.list.d/docker.list > /dev/null
 sudo apt update
 sudo apt install docker-ce -y
 sudo usermod -aG docker ${USER}

--- a/scripts/hypr_keybindings_help.sh
+++ b/scripts/hypr_keybindings_help.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -e
 
-cat <<'EOF' | rofi -dmenu -i -p "Hyprland keys" -theme-str 'listview { lines: 24; }'
+cat << 'EOF' | rofi -dmenu -i -p "Hyprland keys" -theme-str 'listview { lines: 24; }'
 Hyprland Keybindings Cheat Sheet
 ================================
 

--- a/scripts/power_profile_menu.sh
+++ b/scripts/power_profile_menu.sh
@@ -1,12 +1,12 @@
 #!/bin/bash
 set -e
 
-if ! command -v rofi >/dev/null 2>&1; then
+if ! command -v rofi > /dev/null 2>&1; then
     notify-send "Power profile" "rofi is not installed"
     exit 1
 fi
 
-if ! command -v powerprofilesctl >/dev/null 2>&1; then
+if ! command -v powerprofilesctl > /dev/null 2>&1; then
     notify-send "Power profile" "powerprofilesctl is not installed"
     exit 1
 fi

--- a/scripts/screenshot.sh
+++ b/scripts/screenshot.sh
@@ -8,7 +8,7 @@ mkdir -p "$SCREENSHOT_DIR"
 
 take_wayland_screenshot() {
     grim -g "$(slurp)" "$FILENAME"
-    wl-copy <"$FILENAME"
+    wl-copy < "$FILENAME"
 }
 
 take_x11_screenshot() {

--- a/scripts/set_digital_vibrance.sh
+++ b/scripts/set_digital_vibrance.sh
@@ -3,10 +3,10 @@ set -e
 
 DIGITAL_VIBRANCE=57
 
-if ! command -v nvidia-settings >/dev/null 2>&1; then
+if ! command -v nvidia-settings > /dev/null 2>&1; then
     exit 0
 fi
 
 # NVIDIA commonly exposes DigitalVibrance on a 0..63 scale.
 # 57 is ~90% of the maximum value.
-nvidia-settings --assign "[gpu:0]/DigitalVibrance=${DIGITAL_VIBRANCE}" >/dev/null 2>&1 || true
+nvidia-settings --assign "[gpu:0]/DigitalVibrance=${DIGITAL_VIBRANCE}" > /dev/null 2>&1 || true

--- a/scripts/start_keyring.sh
+++ b/scripts/start_keyring.sh
@@ -1,11 +1,11 @@
 #!/bin/bash
 set -e
 
-if ! command -v gnome-keyring-daemon >/dev/null 2>&1; then
+if ! command -v gnome-keyring-daemon > /dev/null 2>&1; then
     exit 0
 fi
 
-if pgrep -x gnome-keyring-daemon >/dev/null 2>&1; then
+if pgrep -x gnome-keyring-daemon > /dev/null 2>&1; then
     exit 0
 fi
 

--- a/scripts/switch_audio_output.sh
+++ b/scripts/switch_audio_output.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -e
 
-if ! command -v pactl >/dev/null 2>&1; then
+if ! command -v pactl > /dev/null 2>&1; then
     notify-send "Audio output" "pactl is not installed"
     exit 1
 fi


### PR DESCRIPTION
## Summary
- format shell scripts to match the CI `shfmt -sr -i 4` rules
- fix spacing around redirections and heredoc formatting where required
- unblock the new shell formatting check in GitHub Actions

## Verification
- `shfmt -d -sr -i 4`
- `bash -n` on all `*.sh` files