### PR TITLE
fix(nvim): restore Noice cmdline stability

### DIFF
--- a/nvim/.config/nvim/lua/plugins/astrolsp.lua
+++ b/nvim/.config/nvim/lua/plugins/astrolsp.lua
@@ -53,11 +53,7 @@ return {
       ty = {
         cmd = { "ty", "server" },
         filetypes = { "python" },
-        root_dir = function(fname)
-          return require("lspconfig.util").root_pattern("pyproject.toml", "ty.toml", "setup.py", "setup.cfg", ".git")(
-            fname
-          )
-        end,
+        root_markers = { "pyproject.toml", "ty.toml", "setup.py", "setup.cfg", ".git" },
         single_file_support = true,
       },
     },
@@ -71,8 +67,6 @@ return {
       -- pyright = function(_, opts) require("lspconfig").pyright.setup(opts) end -- or a custom handler function can be passed
       basedpyright = false,
       pyright = false,
-      ruff = function(_, opts) require("lspconfig").ruff.setup(opts) end,
-      ty = function(_, opts) require("lspconfig").ty.setup(opts) end,
     },
     -- Configure buffer local auto commands to add when attaching a language server
     autocmds = {

--- a/nvim/.config/nvim/lua/plugins/user.lua
+++ b/nvim/.config/nvim/lua/plugins/user.lua
@@ -73,8 +73,8 @@ return {
           event = "notify",
           warning = true,
           any = {
-            { find = "require%('lspconfig'%)" },
-            { find = "vim%.lsp%.with%(%) is deprecated" },
+            { find = "require.*lspconfig" },
+            { find = "vim%.lsp%.with.*deprecated" },
           },
         },
         opts = { skip = true },

--- a/nvim/.config/nvim/lua/plugins/user.lua
+++ b/nvim/.config/nvim/lua/plugins/user.lua
@@ -117,7 +117,7 @@ return {
             :with_del(cond.not_after_regex "xx")
             -- disable adding a newline when you press <cr>
             :with_cr(cond.none()),
-          -- disable for .vim files, but it work for another filetypes
+          -- disable for .vim files, but it works for other filetypes
           Rule("a", "a", "-vim")
         }
       )

--- a/nvim/.config/nvim/lua/plugins/user.lua
+++ b/nvim/.config/nvim/lua/plugins/user.lua
@@ -67,6 +67,7 @@ return {
   {
     "folke/noice.nvim",
     opts = function(_, opts)
+      opts = opts or {}
       opts.routes = opts.routes or {}
       table.insert(opts.routes, 1, {
         filter = {

--- a/nvim/.config/nvim/lua/plugins/user.lua
+++ b/nvim/.config/nvim/lua/plugins/user.lua
@@ -6,7 +6,7 @@ return {
 
   -- == Examples of Adding Plugins ==
 
-  "andweeb/presence.nvim",
+  { "andweeb/presence.nvim", enabled = false },
   {
     "ray-x/lsp_signature.nvim",
     event = "BufRead",
@@ -64,6 +64,25 @@ return {
   -- You can disable default plugins as follows:
   { "max397574/better-escape.nvim", enabled = false },
 
+  {
+    "folke/noice.nvim",
+    opts = function(_, opts)
+      opts.routes = opts.routes or {}
+      table.insert(opts.routes, 1, {
+        filter = {
+          event = "notify",
+          warning = true,
+          any = {
+            { find = "require%('lspconfig'%)" },
+            { find = "vim%.lsp%.with%(%) is deprecated" },
+          },
+        },
+        opts = { skip = true },
+      })
+      return opts
+    end,
+  },
+
   -- You can also easily customize additional setup of plugins that is outside of the plugin's setup call
   {
     "L3MON4D3/LuaSnip",
@@ -98,9 +117,9 @@ return {
             :with_del(cond.not_after_regex "xx")
             -- disable adding a newline when you press <cr>
             :with_cr(cond.none()),
-        },
-        -- disable for .vim files, but it work for another filetypes
-        Rule("a", "a", "-vim")
+          -- disable for .vim files, but it work for another filetypes
+          Rule("a", "a", "-vim")
+        }
       )
     end,
   },


### PR DESCRIPTION
Fix the Neovim startup breakage by disabling the crashing presence.nvim plugin, removing deprecated lspconfig setup handlers in AstroLSP, and filtering noisy Noice deprecation warnings.\n\nVerified with a clean interactive smoke test: pressing ':' now opens the Noice cmdline and remains stable.