### PR TITLE
chore(scripts): enforce strict bash mode

### DIFF
--- a/install_linux.sh
+++ b/install_linux.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
-set -e # Exit immediately if a command exits with a non-zero status
+set -euo pipefail
+IFS=$'\n\t'
 
 # Get the directory of this script
 DOTFILES_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"

--- a/install_mac.sh
+++ b/install_mac.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
-set -e # Exit immediately if a command exits with a non-zero status
+set -euo pipefail
+IFS=$'\n\t'
 
 # Get the directory of this script
 DOTFILES_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"

--- a/install_ubuntu_server.sh
+++ b/install_ubuntu_server.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
-set -e # Exit on any error
+set -euo pipefail
+IFS=$'\n\t'
 
 # Get the directory of this script
 DOTFILES_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"

--- a/scripts/brew-compare.sh
+++ b/scripts/brew-compare.sh
@@ -2,7 +2,8 @@
 # Brewfile comparison script
 # Usage: ./scripts/brew-compare.sh
 
-set -e
+set -euo pipefail
+IFS=$'\n\t'
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(dirname "$SCRIPT_DIR")"

--- a/scripts/common.sh
+++ b/scripts/common.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
-set -e
+set -euo pipefail
+IFS=$'\n\t'
 
 backup_if_exists() {
     local target="$HOME/$1"

--- a/scripts/docker_install.sh
+++ b/scripts/docker_install.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 # install docker and docker compose on stackit
+set -euo pipefail
+IFS=$'\n\t'
 
 sudo apt update
 sudo apt install apt-transport-https ca-certificates curl software-properties-common -y

--- a/scripts/hypr_keybindings_help.sh
+++ b/scripts/hypr_keybindings_help.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
-set -e
+set -euo pipefail
+IFS=$'\n\t'
 
 cat << 'EOF' | rofi -dmenu -i -p "Hyprland keys" -theme-str 'listview { lines: 24; }'
 Hyprland Keybindings Cheat Sheet

--- a/scripts/power_profile_menu.sh
+++ b/scripts/power_profile_menu.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
-set -e
+set -euo pipefail
+IFS=$'\n\t'
 
 if ! command -v rofi > /dev/null 2>&1; then
     notify-send "Power profile" "rofi is not installed"

--- a/scripts/screenshot.sh
+++ b/scripts/screenshot.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
-set -e
+set -euo pipefail
+IFS=$'\n\t'
 
 SCREENSHOT_DIR="$HOME/Pictures/Screenshots"
 FILENAME="$SCREENSHOT_DIR/screenshot_$(date +%Y-%m-%d_%H-%M-%S).png"

--- a/scripts/set_digital_vibrance.sh
+++ b/scripts/set_digital_vibrance.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
-set -e
+set -euo pipefail
+IFS=$'\n\t'
 
 DIGITAL_VIBRANCE=57
 

--- a/scripts/start_keyring.sh
+++ b/scripts/start_keyring.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
-set -e
+set -euo pipefail
+IFS=$'\n\t'
 
 if ! command -v gnome-keyring-daemon > /dev/null 2>&1; then
     exit 0

--- a/scripts/switch_audio_output.sh
+++ b/scripts/switch_audio_output.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
-set -e
+set -euo pipefail
+IFS=$'\n\t'
 
 if ! command -v pactl > /dev/null 2>&1; then
     notify-send "Audio output" "pactl is not installed"


### PR DESCRIPTION
## Summary
- Replace bare `set -e` with `set -euo pipefail; IFS=$'\n\t'` across all 12 shell scripts
- Add the missing strict mode to `scripts/docker_install.sh` (which previously had no error handling)
- Catches unset variables and pipeline failures that were silently ignored

## Why
`set -e` alone misses two whole classes of bugs:
- **Unset variables** silently expand to empty strings (foot-gun for `rm -rf "$VAR/sub"` patterns)
- **Pipeline failures** in the middle of a pipe are swallowed (`curl ... | grep ...` reports success on curl failure)

`docker_install.sh` had nothing at all — a failed `apt install` or `curl` would silently leave the box in a half-installed state.

## Files changed
- `install_mac.sh`, `install_linux.sh`, `install_ubuntu_server.sh`
- `scripts/common.sh`, `scripts/brew-compare.sh`, `scripts/docker_install.sh`
- `scripts/hypr_keybindings_help.sh`, `scripts/power_profile_menu.sh`, `scripts/screenshot.sh`, `scripts/set_digital_vibrance.sh`, `scripts/start_keyring.sh`, `scripts/switch_audio_output.sh`

## Test plan
- [x] `bash -n` syntax check passes for all 12 files
- [ ] Run `install_mac.sh` end-to-end on a clean macOS to confirm no unset-var regressions
- [ ] Run an idempotent re-install to confirm conditional branches still work

## Notes
Verified all scripts use `read -p` patterns or pre-set variables — no `set -u` regressions expected. `IFS=$'\n\t'` prevents word-splitting on spaces in filenames/paths.

🤖 Generated with [Claude Code](https://claude.com/claude-code)