### PR TITLE
fix(hypr): use ~ instead of hardcoded /home/mfm in hyprpaper paths

### DIFF
--- a/hypr/.config/hypr/hyprpaper.conf
+++ b/hypr/.config/hypr/hyprpaper.conf
@@ -2,18 +2,18 @@ splash = false
 
 wallpaper {
   monitor = HDMI-A-1
-  path = /home/mfm/Desktop/005_Eerie_fungal_forest_with_giant_glowing_s.png
+  path = ~/Desktop/005_Eerie_fungal_forest_with_giant_glowing_s.png
   fit_mode = cover
 }
 
 wallpaper {
   monitor = DP-1
-  path = /home/mfm/Desktop/005_Eerie_fungal_forest_with_giant_glowing_s.png
+  path = ~/Desktop/005_Eerie_fungal_forest_with_giant_glowing_s.png
   fit_mode = cover
 }
 
 wallpaper {
   monitor = DP-2
-  path = /home/mfm/Desktop/005_Eerie_fungal_forest_with_giant_glowing_s.png
+  path = ~/Desktop/005_Eerie_fungal_forest_with_giant_glowing_s.png
   fit_mode = cover
 }


### PR DESCRIPTION
## Summary
- Replace hardcoded `/home/mfm/Desktop/...` with `~/Desktop/...` in all three wallpaper blocks of `hyprpaper.conf`
- Hyprpaper expands `~`, so this now works for any user — not just whoever has `$HOME = /home/mfm`

## Why
The path was a copy-paste leftover from the original setup. Stowing this config on any other host (or even on the same host with a different username) would silently fail to load the wallpaper because the file wouldn't exist at that absolute path.

## Test plan
- [ ] Reload hyprpaper (`hyprctl hyprpaper reload`) and confirm wallpaper still renders on all 3 monitors
- [ ] Verify on a fresh checkout that the wallpaper file resolves correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)