### PR TITLE
fix(zed): drop broken CascadiaCove Mono font fallback

### DIFF
--- a/zed/.config/zed/settings.json
+++ b/zed/.config/zed/settings.json
@@ -73,7 +73,7 @@
       "milliseconds": 1000
     }
   },
-  "buffer_font_fallbacks": ["CascadiaCove Mono", "monospace"],
+  "buffer_font_fallbacks": ["monospace"],
   "buffer_font_family": "CaskaydiaCove Nerd Font Mono",
   "file_types": {},
   "auto_indent_on_paste": true,


### PR DESCRIPTION
## Summary
- Remove the typoed `"CascadiaCove Mono"` entry from `buffer_font_fallbacks`
- Fall back through the primary font (`CaskaydiaCove Nerd Font Mono`, already in `buffer_font_family`) and then generic `monospace`

## Why
`"CascadiaCove Mono"` is not a real installed font. Microsoft ships its Cascadia family as `Cascadia Code` / `Cascadia Mono`. The Nerd Font build is `CaskaydiaCove Nerd Font Mono` (already configured as the primary). The fallback array as written did nothing useful — Zed would skip the missing name and land on `monospace` anyway.

## Test plan
- [ ] Open Zed and confirm the buffer renders with `CaskaydiaCove Nerd Font Mono` (no visible change expected)
- [ ] Temporarily uninstall the Nerd Font and confirm Zed falls back to system monospace cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)