### PR TITLE
feat(hypr): add walker launcher support

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,7 +105,8 @@ earlier in `.zshrc` because it is sourced last.
 ├── zed/                     # Zed editor config
 ├── hypr/                    # Hyprland configuration (Linux)
 ├── waybar/                  # Waybar configuration (Linux)
-├── rofi/                    # Rofi launcher config (Linux)
+├── rofi/                    # Rofi launcher config/fallback (Linux)
+├── walker/                  # Walker launcher config (Linux)
 ├── gtk/                     # GTK theming/config (Linux)
 ├── screenlayout/            # Screen layout scripts (Linux)
 ├── scripts/                 # Utility scripts
@@ -133,7 +134,7 @@ cd ~/dotfiles
 stow zsh git nvim ghostty zellij ekphos yazi zed
 
 # Arch Linux / CachyOS
-stow zsh nvim yazi zellij git ghostty ekphos zed dunst hypr waybar rofi gtk
+stow zsh nvim yazi zellij git ghostty ekphos zed dunst hypr waybar rofi walker gtk
 
 # Ubuntu (minimal)
 stow zsh git nvim zellij ekphos

--- a/docs/stow.md
+++ b/docs/stow.md
@@ -18,6 +18,7 @@ This repo uses [GNU Stow](https://www.gnu.org/software/stow/) to manage symlinks
 | `hypr` | `~/.config/hypr` |
 | `waybar` | `~/.config/waybar` |
 | `rofi` | `~/.config/rofi` |
+| `walker` | `~/.config/walker` |
 | `gtk` | `~/.config/gtk-3.0`, `~/.gtkrc-2.0` |
 | `screenlayout` | `~/.screenlayout` |
 
@@ -38,7 +39,7 @@ stow zsh git nvim ghostty zellij ekphos yazi zed
 ### Arch Linux / CachyOS
 
 ```bash
-stow zsh nvim yazi zellij git ghostty ekphos zed dunst hypr waybar rofi gtk
+stow zsh nvim yazi zellij git ghostty ekphos zed dunst hypr waybar rofi walker gtk
 ```
 
 ### Ubuntu (minimal)

--- a/hypr/.config/hypr/hyprland.conf
+++ b/hypr/.config/hypr/hyprland.conf
@@ -2,7 +2,7 @@ $mod = SUPER
 $terminal = ghostty
 $browser = brave
 $file_manager = thunar
-$launcher = rofi -show combi -combi-modes "drun,run,calc"
+$launcher = $HOME/dotfiles/scripts/launcher.sh
 $window_switcher = rofi -show window
 $screenshot = $HOME/dotfiles/scripts/screenshot.sh
 $audio_switcher = $HOME/dotfiles/scripts/switch_audio_output.sh
@@ -25,6 +25,8 @@ exec-once = hyprpaper
 exec-once = dunst
 exec-once = waybar
 exec-once = hypridle
+exec-once = command -v elephant >/dev/null 2>&1 && elephant
+exec-once = command -v walker >/dev/null 2>&1 && command -v elephant >/dev/null 2>&1 && walker --gapplication-service
 exec-once = sleep 2 && $HOME/dotfiles/scripts/set_digital_vibrance.sh
 exec-once = sleep 2 && ghostty
 

--- a/hypr/.config/hypr/hyprland.conf
+++ b/hypr/.config/hypr/hyprland.conf
@@ -25,8 +25,8 @@ exec-once = hyprpaper
 exec-once = dunst
 exec-once = waybar
 exec-once = hypridle
-exec-once = command -v elephant >/dev/null 2>&1 && elephant
-exec-once = command -v walker >/dev/null 2>&1 && command -v elephant >/dev/null 2>&1 && sleep 0.5 && walker --gapplication-service
+exec-once = command -v elephant >/dev/null 2>&1 && exec elephant
+exec-once = command -v walker >/dev/null 2>&1 && command -v elephant >/dev/null 2>&1 && sleep 0.5 && exec walker --gapplication-service
 exec-once = sleep 2 && $HOME/dotfiles/scripts/set_digital_vibrance.sh
 exec-once = sleep 2 && ghostty
 

--- a/hypr/.config/hypr/hyprland.conf
+++ b/hypr/.config/hypr/hyprland.conf
@@ -26,7 +26,7 @@ exec-once = dunst
 exec-once = waybar
 exec-once = hypridle
 exec-once = command -v elephant >/dev/null 2>&1 && elephant
-exec-once = command -v walker >/dev/null 2>&1 && command -v elephant >/dev/null 2>&1 && walker --gapplication-service
+exec-once = command -v walker >/dev/null 2>&1 && command -v elephant >/dev/null 2>&1 && sleep 0.5 && walker --gapplication-service
 exec-once = sleep 2 && $HOME/dotfiles/scripts/set_digital_vibrance.sh
 exec-once = sleep 2 && ghostty
 

--- a/install_linux.sh
+++ b/install_linux.sh
@@ -60,6 +60,7 @@ paru -S --needed --noconfirm \
     qt6-wayland \
     rofi-wayland \
     rofi-calc \
+    walker \
     wlogout \
     grim \
     slurp \
@@ -95,6 +96,14 @@ AUR_PACKAGES=(
     discord
     witr-bin
     cliphist
+    elephant-bin
+    elephant-desktopapplications-bin
+    elephant-calc-bin
+    elephant-runner-bin
+    elephant-websearch-bin
+    elephant-clipboard-bin
+    elephant-providerlist-bin
+    elephant-windows-bin
 )
 
 if [ "$POWERLEVEL10K_INSTALLED_FROM_REPO" -eq 0 ]; then
@@ -357,12 +366,13 @@ backup_if_exists ".config/zed"
 backup_if_exists ".config/dunst"
 backup_if_exists ".config/waybar"
 backup_if_exists ".config/rofi"
+backup_if_exists ".config/walker"
 backup_if_exists ".config/gtk-3.0"
 backup_if_exists ".config/gtk-4.0"
 backup_if_exists ".gtkrc-2.0"
 
 # Run stow
-stow zsh nvim yazi zellij git ghostty ekphos zed dunst hypr waybar rofi gtk
+stow zsh nvim yazi zellij git ghostty ekphos zed dunst hypr waybar rofi walker gtk
 
 # ==============================================================================
 # 15. Apply GTK Dark Theme Preference

--- a/scripts/launcher.sh
+++ b/scripts/launcher.sh
@@ -3,13 +3,16 @@ set -e
 
 # Prefer Walker on Wayland; keep rofi as a fallback until Walker + Elephant are installed.
 if command -v walker > /dev/null 2>&1 && command -v elephant > /dev/null 2>&1; then
+    LOG_DIR="${XDG_RUNTIME_DIR:-${XDG_CACHE_HOME:-$HOME/.cache}/dotfiles}"
+    mkdir -p "$LOG_DIR"
+
     if ! pgrep -x elephant > /dev/null 2>&1; then
-        elephant > /tmp/elephant.log 2>&1 &
+        elephant > "$LOG_DIR/elephant.log" 2>&1 &
         sleep 0.3
     fi
 
-    if ! pgrep -af 'walker --gapplication-service' > /dev/null 2>&1; then
-        walker --gapplication-service > /tmp/walker.log 2>&1 &
+    if ! pgrep -f 'walker --gapplication-service' > /dev/null 2>&1; then
+        walker --gapplication-service > "$LOG_DIR/walker.log" 2>&1 &
         sleep 0.2
     fi
 

--- a/scripts/launcher.sh
+++ b/scripts/launcher.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+set -e
+
+# Prefer Walker on Wayland; keep rofi as a fallback until Walker + Elephant are installed.
+if command -v walker > /dev/null 2>&1 && command -v elephant > /dev/null 2>&1; then
+    if ! pgrep -x elephant > /dev/null 2>&1; then
+        elephant > /tmp/elephant.log 2>&1 &
+        sleep 0.3
+    fi
+
+    if ! pgrep -af 'walker --gapplication-service' > /dev/null 2>&1; then
+        walker --gapplication-service > /tmp/walker.log 2>&1 &
+        sleep 0.2
+    fi
+
+    exec walker
+fi
+
+if command -v walker > /dev/null 2>&1 && ! command -v elephant > /dev/null 2>&1; then
+    notify-send "Walker" "Missing Elephant backend; falling back to rofi" 2> /dev/null || true
+fi
+
+exec rofi -show combi -combi-modes "drun,run,calc"

--- a/walker/.config/walker/config.toml
+++ b/walker/.config/walker/config.toml
@@ -1,0 +1,59 @@
+force_keyboard_focus = true
+close_when_open = true
+click_to_close = true
+selection_wrap = true
+theme = "default"
+
+[placeholders]
+"default" = { input = "Search", list = "No Results" }
+"desktopapplications" = { input = "Launch app", list = "No apps" }
+"calc" = { input = "Calculate", list = "Enter expression" }
+"runner" = { input = "Run command", list = "No commands" }
+"websearch" = { input = "Search web", list = "" }
+"clipboard" = { input = "Clipboard", list = "Clipboard empty" }
+
+[keybinds]
+close = ["Escape"]
+next = ["Down", "ctrl j"]
+previous = ["Up", "ctrl k"]
+toggle_exact = ["ctrl e"]
+resume_last_query = ["ctrl r"]
+quick_activate = ["F1", "F2", "F3", "F4"]
+
+[providers]
+default = [
+  "desktopapplications",
+  "calc",
+  "runner",
+  "websearch",
+  "clipboard",
+]
+empty = ["desktopapplications", "clipboard"]
+max_results = 50
+
+[providers.clipboard]
+time_format = "relative"
+
+[[providers.prefixes]]
+prefix = ";"
+provider = "providerlist"
+
+[[providers.prefixes]]
+prefix = ">"
+provider = "runner"
+
+[[providers.prefixes]]
+prefix = "="
+provider = "calc"
+
+[[providers.prefixes]]
+prefix = "@"
+provider = "websearch"
+
+[[providers.prefixes]]
+prefix = ":"
+provider = "clipboard"
+
+[[providers.prefixes]]
+prefix = "$"
+provider = "windows"


### PR DESCRIPTION
## Summary
- add Walker config with application, runner, calc, websearch, and clipboard providers
- route Super+D through a launcher script that prefers Walker and falls back to rofi
- install and stow Walker/Elephant dependencies for Linux setup

## Validation
- bash syntax check for launcher and install scripts
- TOML parse check for Walker config
- stow dry-run for Walker config