### PR TITLE
fix(zsh): drop ZOXIDE_CMD_OVERRIDE to silence cd warning

### DIFF
--- a/zsh/.zshrc
+++ b/zsh/.zshrc
@@ -2,8 +2,11 @@ if [[ -r "${XDG_CACHE_HOME:-$HOME/.cache}/p10k-instant-prompt-${(%):-%n}.zsh" ]]
     source "${XDG_CACHE_HOME:-$HOME/.cache}/p10k-instant-prompt-${(%):-%n}.zsh"
 fi
 
-# Configure zoxide to override cd command directly
-export ZOXIDE_CMD_OVERRIDE="cd"
+# Note: we intentionally do NOT set ZOXIDE_CMD_OVERRIDE here.
+# The zoxide oh-my-zsh plugin would override `cd` itself, but we define our
+# own `cd()` wrapper below (trailing-slash normalization). Letting the plugin
+# also claim `cd` triggers zoxide's "redefined after init" warning. By leaving
+# the override unset, our wrapper is the sole `cd`, and the warning disappears.
 
 # Echo the matched directory before navigating
 export _ZO_ECHO=1


### PR DESCRIPTION
## What

Remove `export ZOXIDE_CMD_OVERRIDE="cd"` from `zsh/.zshrc`, replacing it with an explanatory comment.

## Why

The zoxide oh-my-zsh plugin used `ZOXIDE_CMD_OVERRIDE` to claim `cd`. We then define our own `cd()` wrapper later in `.zshrc` (for trailing-slash normalization), which redefines `cd` after zoxide's init. Recent zoxide versions detect this and print:

```
zoxide: detected a possible configuration issue.
Please ensure that zoxide is initialized right at the end of your shell configuration file (usually ~/.zshrc).
```

The warning is cosmetic (the wrapper still delegates to `__zoxide_z`), but it leaks into non-interactive subprocesses. Leaving the override unset makes our wrapper the sole `cd`, so nothing is redefined after init and the warning disappears.

## Testing

- New interactive shell: warning gone.
- `cd <partial>` still jumps via zoxide.
- `cd <dir>/` (trailing slash) still works via the wrapper.

🤖 Generated with [Claude Code](https://claude.com/claude-code)