### PR TITLE
chore(opencode): remove empty opencode stow package

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -82,7 +82,6 @@ Place configs in appropriate directories:
 - `ghostty/.config/ghostty/` - Ghostty terminal config
 - `yazi/.config/yazi/` - Yazi file manager config
 - `zed/.config/zed/` - Zed editor config
-- `opencode/.config/opencode/` - OpenCode AI coding agent config (personal install only)
 - `scripts/` - Utility scripts
 
 ### Platform-Specific Handling


### PR DESCRIPTION
## Summary

Removes the abandoned `opencode/` stow package.

## Problem

The `opencode/` stow package contained only an empty `rules/` directory:
- It had **no tracked files** (empty dirs aren't tracked by git)
- It was **never stowed** by any install script
- `README.md` states AI agent configs live in a separate repo ([ai_agent_dotfiles](https://github.com/mfmezger/ai_agent_dotfiles))

## Changes

- Deleted the local empty `opencode/` directory
- Removed the dangling reference from `AGENTS.md` (File Organization section)

## Not affected

The `opencode` CLI tool is unrelated and remains untouched:
- `Brewfile.personal` (`brew "opencode"`)
- `zsh/.zshrc` (`abbr oc="opencode"`)
- `docs/shortcuts.md` (`oc` → `opencode`)