### PR TITLE
refactor(nvim): remove AstroNvim template leftovers from user.lua

### DIFF
--- a/nvim/.config/nvim/lua/plugins/user.lua
+++ b/nvim/.config/nvim/lua/plugins/user.lua
@@ -1,17 +1,5 @@
--- You can also add or configure plugins by creating files in this `plugins/` folder
--- Here are some examples:
-
 ---@type LazySpec
 return {
-
-  -- == Examples of Adding Plugins ==
-
-  "andweeb/presence.nvim",
-  {
-    "ray-x/lsp_signature.nvim",
-    event = "BufRead",
-    config = function() require("lsp_signature").setup() end,
-  },
 
   -- Oil.nvim: Edit filesystem like a buffer
   {
@@ -36,8 +24,6 @@ return {
     event = "VeryLazy",
     opts = {},
   },
-
-  -- == Examples of Overriding Plugins ==
 
   -- customize alpha options
   {
@@ -72,36 +58,6 @@ return {
       -- add more custom luasnip configuration such as filetype extend or custom snippets
       local luasnip = require "luasnip"
       luasnip.filetype_extend("javascript", { "javascriptreact" })
-    end,
-  },
-
-  {
-    "windwp/nvim-autopairs",
-    config = function(plugin, opts)
-      require "astronvim.plugins.configs.nvim-autopairs"(plugin, opts) -- include the default astronvim config that calls the setup call
-      -- add more custom autopairs configuration such as custom rules
-      local npairs = require "nvim-autopairs"
-      local Rule = require "nvim-autopairs.rule"
-      local cond = require "nvim-autopairs.conds"
-      npairs.add_rules(
-        {
-          Rule("$", "$", { "tex", "latex" })
-            -- don't add a pair if the next character is %
-            :with_pair(cond.not_after_regex "%%")
-            -- don't add a pair if  the previous character is xxx
-            :with_pair(
-              cond.not_before_regex("xxx", 3)
-            )
-            -- don't move right when repeat character
-            :with_move(cond.none())
-            -- don't delete if the next character is xx
-            :with_del(cond.not_after_regex "xx")
-            -- disable adding a newline when you press <cr>
-            :with_cr(cond.none()),
-        },
-        -- disable for .vim files, but it work for another filetypes
-        Rule("a", "a", "-vim")
-      )
     end,
   },
 }


### PR DESCRIPTION
## Summary

Removes unedited AstroNvim template examples that were never customized.

## Removed

- `andweeb/presence.nvim` — Discord rich presence (template default, likely unwanted)
- `ray-x/lsp_signature.nvim` — template example, no customization
- `windwp/nvim-autopairs` override — contained placeholder `"xxx"`/`"xx"` strings straight from the template, with no real rules
- `"Here are some examples"` / `"Examples of Adding/Overriding Plugins"` scaffolding comments

## Kept (real customizations)

- `oil.nvim` (filesystem editing via `-`)
- `nvim-surround`
- `alpha-nvim` dashboard header
- `better-escape.nvim` disable
- `LuaSnip` filetype extend (`javascript` → `javascriptreact`)

File reduced from 107 → 63 lines.