### PR TITLE
refactor(zsh): remove deprecated uu function

### DIFF
--- a/zsh/.zshrc
+++ b/zsh/.zshrc
@@ -166,17 +166,9 @@ abbr --quiet --session kgp='kubectl get pods'
 if [[ "$OSTYPE" == "darwin"* ]]; then
     # macOS update command
     abbr --quiet --session update="brew update && brew upgrade && brew cu -f -a && tldr --update && omz update"
-    function uu() {
-        echo "⚠️  'uu' is deprecated, please use 'update' instead"
-        brew update && brew upgrade && brew cu -f -a && tldr --update && omz update
-    }
 elif [[ "$OSTYPE" == "linux-gnu"* ]]; then
     # Arch Linux update command
     abbr --quiet --session update="paru -Syyu --noconfirm && tldr --update && omz update"
-    function uu() {
-        echo "⚠️  'uu' is deprecated, please use 'update' instead"
-        paru -Syyu --noconfirm && tldr --update && omz update
-    }
     # Zed editor is called 'zeditor' on Linux
     alias zed="zeditor"
     abbr --quiet --session nvitop="uvx nvitop"


### PR DESCRIPTION
## Summary

Removes the deprecated `uu()` function from the platform-specific update block in `.zshrc`.

## Problem

`uu()` was a deprecated wrapper that printed a deprecation warning and then duplicated exactly what the `update` abbreviation already does. It existed in both the macOS and Linux (`linux-gnu`) branches.

## Changes

- Removed the macOS `uu()` definition (4 lines)
- Removed the Linux `uu()` definition (4 lines)
- The `update` abbreviation (the documented replacement) is unchanged in both branches

`docs/shortcuts.md` already documents `update` as the command to use.