### PR TITLE
build(deps): add go-task to installers

### DIFF
--- a/Brewfile.minimal
+++ b/Brewfile.minimal
@@ -39,6 +39,7 @@ brew "bat"                                                     # cat replacement
 # DEVELOPMENT TOOLS (Referenced in zsh config)
 # ==============================================================================
 brew "go"                                                      # Go language (PATH in .zshrc)
+brew "go-task"                                                 # Task runner
 brew "gh"                                                      # GitHub CLI (completions)
 brew "git-delta"                                               # Git pager
 brew "fastfetch"                                               # System info (ff alias)

--- a/install_linux.sh
+++ b/install_linux.sh
@@ -49,6 +49,7 @@ paru -S --needed --noconfirm \
     xclip \
     zed \
     go \
+    go-task \
     scrot \
     dunst \
     hyprland \


### PR DESCRIPTION
## Summary
- Add go-task to the minimal Homebrew bundle
- Add go-task to the Arch/CachyOS paru install list

## Test
- bash -n install_linux.sh