### PR TITLE
perf(zsh): parallelize and add cleanup to update command

### DIFF
--- a/zsh/.zshrc
+++ b/zsh/.zshrc
@@ -166,10 +166,12 @@ abbr --quiet --session kgp='kubectl get pods'
 # Platform-specific update aliases
 if [[ "$OSTYPE" == "darwin"* ]]; then
     # macOS update command
-    abbr --quiet --session update="brew update && brew upgrade && brew cu -f -a && tldr --update && omz update"
+    # tldr + omz run in parallel (independent of brew); cleanup at the end.
+    abbr --quiet --session update="brew update && brew upgrade && brew cu -f -a && { tldr --update & omz update & wait; } && brew cleanup"
 elif [[ "$OSTYPE" == "linux-gnu"* ]]; then
     # Arch Linux update command
-    abbr --quiet --session update="paru -Syyu --noconfirm && tldr --update && omz update"
+    # tldr + omz run in parallel (independent of paru); cleanup at the end.
+    abbr --quiet --session update="paru -Syyu --noconfirm && { tldr --update & omz update & wait; } && paru -Sc --noconfirm"
     # Zed editor is called 'zeditor' on Linux
     alias zed="zeditor"
     abbr --quiet --session nvitop="uvx nvitop"

--- a/zsh/.zshrc
+++ b/zsh/.zshrc
@@ -167,11 +167,15 @@ abbr --quiet --session kgp='kubectl get pods'
 if [[ "$OSTYPE" == "darwin"* ]]; then
     # macOS update command
     # tldr + omz run in parallel (independent of brew); cleanup at the end.
-    abbr --quiet --session update="brew update && brew upgrade && brew cu -f -a && { tldr --update & omz update & wait; } && brew cleanup"
+    # wait on each PID so a failed update propagates and halts before cleanup;
+    # single quotes keep $! / $pid unexpanded until the abbr runs.
+    abbr --quiet --session update='brew update && brew upgrade && brew cu -f -a && { tldr --update & pid1=$!; omz update & pid2=$!; wait $pid1 && wait $pid2; } && brew cleanup'
 elif [[ "$OSTYPE" == "linux-gnu"* ]]; then
     # Arch Linux update command
     # tldr + omz run in parallel (independent of paru); cleanup at the end.
-    abbr --quiet --session update="paru -Syyu --noconfirm && { tldr --update & omz update & wait; } && paru -Sc --noconfirm"
+    # wait on each PID so a failed update propagates and halts before cleanup;
+    # single quotes keep $! / $pid unexpanded until the abbr runs.
+    abbr --quiet --session update='paru -Syyu --noconfirm && { tldr --update & pid1=$!; omz update & pid2=$!; wait $pid1 && wait $pid2; } && paru -Sc --noconfirm'
     # Zed editor is called 'zeditor' on Linux
     alias zed="zeditor"
     abbr --quiet --session nvitop="uvx nvitop"


### PR DESCRIPTION
## Summary
Optimizes the `update` abbreviation in `zsh/.zshrc`.

## Changes
- **Parallelized independent steps**: `tldr --update` and `omz update` now run concurrently (`{ ... & ... & wait; }`) since they don't depend on the package managers — saves the sum of their (network-bound) runtimes.
- **Added cleanup**: appended `brew cleanup` (macOS) and `paru -Sc --noconfirm` (Arch) to reclaim disk space.
- Kept `&&` chaining (stop on first failure) and kept it as an abbreviation.

### Before
- macOS: `brew update && brew upgrade && brew cu -f -a && tldr --update && omz update`
- Arch: `paru -Syyu --noconfirm && tldr --update && omz update`

### After
- macOS: `brew update && brew upgrade && brew cu -f -a && { tldr --update & omz update & wait; } && brew cleanup`
- Arch: `paru -Syyu --noconfirm && { tldr --update & omz update & wait; } && paru -Sc --noconfirm`

## Verification
- `zsh -n zsh/.zshrc` passes (syntax OK).