### PR TITLE
refactor(install): add ensure_tool/ensure_repo helpers (candidate 2)

### DIFF
--- a/install_linux.sh
+++ b/install_linux.sh
@@ -8,7 +8,7 @@ echo ">>> Starting Arch Linux / CachyOS Installation from $DOTFILES_DIR <<<"
 
 source "$DOTFILES_DIR/scripts/common.sh"
 
-if ! command -v paru &> /dev/null; then
+if ! command -v paru &>/dev/null; then
     echo ">>> paru is required but not installed <<<"
     echo ">>> Install paru first, then re-run this script <<<"
     exit 1
@@ -76,10 +76,10 @@ paru -S --needed --noconfirm \
 
 # Install the packaged Powerlevel10k when available to avoid AUR conflicts
 POWERLEVEL10K_INSTALLED_FROM_REPO=0
-if paru -Q zsh-theme-powerlevel10k &> /dev/null; then
+if paru -Q zsh-theme-powerlevel10k &>/dev/null; then
     echo ">>> zsh-theme-powerlevel10k already installed <<<"
     POWERLEVEL10K_INSTALLED_FROM_REPO=1
-elif paru --repo -Si zsh-theme-powerlevel10k &> /dev/null; then
+elif paru --repo -Si zsh-theme-powerlevel10k &>/dev/null; then
     echo ">>> Installing zsh-theme-powerlevel10k from repos via paru <<<"
     paru --repo -S --needed --noconfirm zsh-theme-powerlevel10k
     POWERLEVEL10K_INSTALLED_FROM_REPO=1
@@ -152,7 +152,7 @@ if [[ $REPLY =~ ^[Yy]$ ]]; then
     else
         echo ">>> Installing NVIDIA drivers via distro tooling when available <<<"
         # nvidia-inst exists on some Arch-based distros and picks a suitable stack.
-        if command -v nvidia-inst &> /dev/null; then
+        if command -v nvidia-inst &>/dev/null; then
             nvidia-inst
         else
             echo ">>> nvidia-inst not found, installing generic nvidia packages <<<"
@@ -196,37 +196,17 @@ fi
 
 ZSH_CUSTOM="$HOME/.oh-my-zsh/custom"
 
-echo ">>> Installing zsh-autosuggestions <<<"
-if [ ! -d "$ZSH_CUSTOM/plugins/zsh-autosuggestions" ]; then
-    git clone https://github.com/zsh-users/zsh-autosuggestions "$ZSH_CUSTOM/plugins/zsh-autosuggestions"
-else
-    echo ">>> zsh-autosuggestions already installed <<<"
-fi
-
-echo ">>> Installing zsh-syntax-highlighting <<<"
-if [ ! -d "$ZSH_CUSTOM/plugins/zsh-syntax-highlighting" ]; then
-    git clone https://github.com/zsh-users/zsh-syntax-highlighting.git "$ZSH_CUSTOM/plugins/zsh-syntax-highlighting"
-else
-    echo ">>> zsh-syntax-highlighting already installed <<<"
-fi
-
-echo ">>> Installing zsh-autosuggestions-abbreviations-strategy <<<"
-if [ ! -d "$HOME/.local/share/zsh-autosuggestions-abbreviations-strategy" ]; then
-    git clone https://github.com/olets/zsh-autosuggestions-abbreviations-strategy.git \
-        "$HOME/.local/share/zsh-autosuggestions-abbreviations-strategy"
-else
-    echo ">>> zsh-autosuggestions-abbreviations-strategy already installed <<<"
-fi
+ensure_repo "$ZSH_CUSTOM/plugins/zsh-autosuggestions" \
+    https://github.com/zsh-users/zsh-autosuggestions
+ensure_repo "$ZSH_CUSTOM/plugins/zsh-syntax-highlighting" \
+    https://github.com/zsh-users/zsh-syntax-highlighting.git
+ensure_repo "$HOME/.local/share/zsh-autosuggestions-abbreviations-strategy" \
+    https://github.com/olets/zsh-autosuggestions-abbreviations-strategy.git
 
 # ==============================================================================
 # 7. Install Python Tools (uv & commitizen)
 # ==============================================================================
-echo ">>> Installing uv <<<"
-if ! command -v uv &> /dev/null; then
-    curl -LsSf https://astral.sh/uv/install.sh | sh
-else
-    echo ">>> uv already installed <<<"
-fi
+ensure_tool uv "uv" 'curl -LsSf https://astral.sh/uv/install.sh | sh'
 
 # Ensure uv is in PATH for this session
 export PATH="$HOME/.local/bin:$PATH"
@@ -234,30 +214,21 @@ export PATH="$HOME/.local/bin:$PATH"
 # ==============================================================================
 # 8. Install Rust Toolchain (rustup)
 # ==============================================================================
-echo ">>> Installing rustup <<<"
-if ! command -v rustup &> /dev/null; then
-    curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --no-modify-path
-else
-    echo ">>> rustup already installed <<<"
-fi
+ensure_tool rustup "rustup" \
+    "curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --no-modify-path"
 
 if [ -f "$HOME/.cargo/env" ]; then
     . "$HOME/.cargo/env"
 fi
 
-if ! cargo --version &> /dev/null; then
+if ! cargo --version &>/dev/null; then
     echo ">>> Configuring default Rust toolchain (stable) <<<"
     rustup default stable
 else
     echo ">>> Rust toolchain already configured <<<"
 fi
 
-echo ">>> Installing ekphos via cargo <<<"
-if ! command -v ekphos &> /dev/null; then
-    cargo install ekphos --locked
-else
-    echo ">>> ekphos already installed <<<"
-fi
+ensure_tool ekphos "ekphos" "cargo install ekphos --locked"
 
 echo ">>> Installing commitizen via uv <<<"
 uv tool install commitizen
@@ -270,16 +241,16 @@ COMPLETIONS_DIR="$HOME/.local/share/zsh/completions"
 mkdir -p "$COMPLETIONS_DIR"
 
 # Generate uv completions
-if command -v uv &> /dev/null; then
+if command -v uv &>/dev/null; then
     echo ">>> Generating uv/uvx completions <<<"
-    uv generate-shell-completion zsh > "$COMPLETIONS_DIR/_uv"
-    uvx --generate-shell-completion zsh > "$COMPLETIONS_DIR/_uvx"
+    uv generate-shell-completion zsh >"$COMPLETIONS_DIR/_uv"
+    uvx --generate-shell-completion zsh >"$COMPLETIONS_DIR/_uvx"
 fi
 
 # Generate atuin init script
-if command -v atuin &> /dev/null; then
+if command -v atuin &>/dev/null; then
     echo ">>> Generating atuin completions <<<"
-    atuin init zsh > "$COMPLETIONS_DIR/atuin-init.zsh"
+    atuin init zsh >"$COMPLETIONS_DIR/atuin-init.zsh"
     echo ">>> Importing shell history into atuin <<<"
     atuin import auto || {
         echo ">>> Warning: Failed to import shell history into atuin."
@@ -288,27 +259,27 @@ if command -v atuin &> /dev/null; then
 fi
 
 # Generate GitHub CLI completions
-if command -v gh &> /dev/null; then
+if command -v gh &>/dev/null; then
     echo ">>> Generating gh completions <<<"
-    gh completion -s zsh > "$COMPLETIONS_DIR/_gh"
+    gh completion -s zsh >"$COMPLETIONS_DIR/_gh"
 fi
 
 # Generate Docker completions
-if command -v docker &> /dev/null; then
+if command -v docker &>/dev/null; then
     echo ">>> Generating docker completions <<<"
-    docker completion zsh > "$COMPLETIONS_DIR/_docker"
+    docker completion zsh >"$COMPLETIONS_DIR/_docker"
 fi
 
 # Generate kubectl completions (if installed)
-if command -v kubectl &> /dev/null; then
+if command -v kubectl &>/dev/null; then
     echo ">>> Generating kubectl completions <<<"
-    kubectl completion zsh > "$COMPLETIONS_DIR/_kubectl"
+    kubectl completion zsh >"$COMPLETIONS_DIR/_kubectl"
 fi
 
 # Generate helm completions (if installed)
-if command -v helm &> /dev/null; then
+if command -v helm &>/dev/null; then
     echo ">>> Generating helm completions <<<"
-    helm completion zsh > "$COMPLETIONS_DIR/_helm"
+    helm completion zsh >"$COMPLETIONS_DIR/_helm"
 fi
 
 # ==============================================================================
@@ -381,9 +352,9 @@ stow zsh nvim yazi zellij git ghostty ekphos zed dunst hypr waybar rofi walker g
 # 15. Apply GTK Dark Theme Preference
 # ==============================================================================
 echo ">>> Applying GTK dark theme preference <<<"
-if command -v gsettings &> /dev/null; then
+if command -v gsettings &>/dev/null; then
     run_gsettings() {
-        if [ -z "${DBUS_SESSION_BUS_ADDRESS:-}" ] && command -v dbus-run-session &> /dev/null; then
+        if [ -z "${DBUS_SESSION_BUS_ADDRESS:-}" ] && command -v dbus-run-session &>/dev/null; then
             dbus-run-session -- gsettings "$@"
         else
             gsettings "$@"

--- a/install_mac.sh
+++ b/install_mac.sh
@@ -9,7 +9,7 @@ echo ">>> Starting Installation from $DOTFILES_DIR <<<"
 source "$DOTFILES_DIR/scripts/common.sh"
 
 # 1. Install Homebrew
-if ! command -v brew &> /dev/null; then
+if ! command -v brew &>/dev/null; then
     echo ">>> Installing Homebrew <<<"
     /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
 
@@ -46,27 +46,18 @@ else
 fi
 
 # 3. Install Python tools (uv)
-echo ">>> Installing uv <<<"
-if ! command -v uv &> /dev/null; then
-    curl -LsSf https://astral.sh/uv/install.sh | sh
-else
-    echo ">>> uv already installed <<<"
-fi
+ensure_tool uv "uv" 'curl -LsSf https://astral.sh/uv/install.sh | sh'
 
 # 4. Install Rust toolchain (full install only)
 if [[ ! $MINIMAL_INSTALL =~ ^[Yy]$ ]]; then
-    echo ">>> Installing rustup <<<"
-    if ! command -v rustup &> /dev/null; then
-        curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --no-modify-path
-    else
-        echo ">>> rustup already installed <<<"
-    fi
+    ensure_tool rustup "rustup" \
+        "curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --no-modify-path"
 
     if [ -f "$HOME/.cargo/env" ]; then
         . "$HOME/.cargo/env"
     fi
 
-    if ! cargo --version &> /dev/null; then
+    if ! cargo --version &>/dev/null; then
         echo ">>> Configuring default Rust toolchain (stable) <<<"
         rustup default stable
     else
@@ -87,26 +78,12 @@ fi
 # 6. Install Zsh Plugins & Themes
 ZSH_CUSTOM="${ZSH_CUSTOM:-$HOME/.oh-my-zsh/custom}"
 
-echo ">>> Installing Powerlevel10k <<<"
-if [ ! -d "$ZSH_CUSTOM/themes/powerlevel10k" ]; then
-    git clone --depth=1 https://github.com/romkatv/powerlevel10k.git "$ZSH_CUSTOM/themes/powerlevel10k"
-else
-    echo ">>> Powerlevel10k already installed <<<"
-fi
-
-echo ">>> Installing zsh-autosuggestions <<<"
-if [ ! -d "$ZSH_CUSTOM/plugins/zsh-autosuggestions" ]; then
-    git clone https://github.com/zsh-users/zsh-autosuggestions "$ZSH_CUSTOM/plugins/zsh-autosuggestions"
-else
-    echo ">>> zsh-autosuggestions already installed <<<"
-fi
-
-echo ">>> Installing zsh-syntax-highlighting <<<"
-if [ ! -d "$ZSH_CUSTOM/plugins/zsh-syntax-highlighting" ]; then
-    git clone https://github.com/zsh-users/zsh-syntax-highlighting.git "$ZSH_CUSTOM/plugins/zsh-syntax-highlighting"
-else
-    echo ">>> zsh-syntax-highlighting already installed <<<"
-fi
+ensure_repo "$ZSH_CUSTOM/themes/powerlevel10k" \
+    https://github.com/romkatv/powerlevel10k.git --depth=1
+ensure_repo "$ZSH_CUSTOM/plugins/zsh-autosuggestions" \
+    https://github.com/zsh-users/zsh-autosuggestions
+ensure_repo "$ZSH_CUSTOM/plugins/zsh-syntax-highlighting" \
+    https://github.com/zsh-users/zsh-syntax-highlighting.git
 
 # 7. Generate Static Completions (Pre-cached for faster shell startup)
 echo ">>> Generating shell completions <<<"
@@ -114,16 +91,16 @@ COMPLETIONS_DIR="$HOME/.local/share/zsh/completions"
 mkdir -p "$COMPLETIONS_DIR"
 
 # Generate uv completions
-if command -v uv &> /dev/null; then
+if command -v uv &>/dev/null; then
     echo ">>> Generating uv/uvx completions <<<"
-    uv generate-shell-completion zsh > "$COMPLETIONS_DIR/_uv"
-    uvx --generate-shell-completion zsh > "$COMPLETIONS_DIR/_uvx"
+    uv generate-shell-completion zsh >"$COMPLETIONS_DIR/_uv"
+    uvx --generate-shell-completion zsh >"$COMPLETIONS_DIR/_uvx"
 fi
 
 # Generate atuin init script
-if command -v atuin &> /dev/null; then
+if command -v atuin &>/dev/null; then
     echo ">>> Generating atuin completions <<<"
-    atuin init zsh > "$COMPLETIONS_DIR/atuin-init.zsh"
+    atuin init zsh >"$COMPLETIONS_DIR/atuin-init.zsh"
     echo ">>> Importing shell history into atuin <<<"
     atuin import auto || {
         echo ">>> Warning: Failed to import shell history into atuin."
@@ -132,27 +109,27 @@ if command -v atuin &> /dev/null; then
 fi
 
 # Generate GitHub CLI completions
-if command -v gh &> /dev/null; then
+if command -v gh &>/dev/null; then
     echo ">>> Generating gh completions <<<"
-    gh completion -s zsh > "$COMPLETIONS_DIR/_gh"
+    gh completion -s zsh >"$COMPLETIONS_DIR/_gh"
 fi
 
 # Generate Docker completions (full install only)
-if [[ ! $MINIMAL_INSTALL =~ ^[Yy]$ ]] && command -v docker &> /dev/null; then
+if [[ ! $MINIMAL_INSTALL =~ ^[Yy]$ ]] && command -v docker &>/dev/null; then
     echo ">>> Generating docker completions <<<"
-    docker completion zsh > "$COMPLETIONS_DIR/_docker"
+    docker completion zsh >"$COMPLETIONS_DIR/_docker"
 fi
 
 # Generate kubectl completions (full install only)
-if [[ ! $MINIMAL_INSTALL =~ ^[Yy]$ ]] && command -v kubectl &> /dev/null; then
+if [[ ! $MINIMAL_INSTALL =~ ^[Yy]$ ]] && command -v kubectl &>/dev/null; then
     echo ">>> Generating kubectl completions <<<"
-    kubectl completion zsh > "$COMPLETIONS_DIR/_kubectl"
+    kubectl completion zsh >"$COMPLETIONS_DIR/_kubectl"
 fi
 
 # Generate helm completions (full install only)
-if [[ ! $MINIMAL_INSTALL =~ ^[Yy]$ ]] && command -v helm &> /dev/null; then
+if [[ ! $MINIMAL_INSTALL =~ ^[Yy]$ ]] && command -v helm &>/dev/null; then
     echo ">>> Generating helm completions <<<"
-    helm completion zsh > "$COMPLETIONS_DIR/_helm"
+    helm completion zsh >"$COMPLETIONS_DIR/_helm"
 fi
 
 # 8. Link Dotfiles

--- a/install_ubuntu_server.sh
+++ b/install_ubuntu_server.sh
@@ -56,7 +56,7 @@ fi
 
 # Try to install eza via apt (available in Ubuntu 24.04+)
 echo "📦 Installing eza..."
-if sudo apt install -y rust-eza 2> /dev/null; then
+if sudo apt install -y rust-eza 2>/dev/null; then
     echo "✅ eza installed via apt"
     # Create symlink if eza binary has different name
     if [ -f /usr/bin/eza ] && [ ! -f /usr/local/bin/eza ]; then
@@ -64,7 +64,7 @@ if sudo apt install -y rust-eza 2> /dev/null; then
     fi
 else
     echo "📥 eza not available via apt, installing from binary..."
-    if ! command -v eza &> /dev/null; then
+    if ! command -v eza &>/dev/null; then
         wget -qO- https://raw.githubusercontent.com/eza-community/eza/main/deb.asc | sudo gpg --dearmor -o /etc/apt/keyrings/gierens.gpg
         echo "deb [signed-by=/etc/apt/keyrings/gierens.gpg] http://deb.gierens.de stable main" | sudo tee /etc/apt/sources.list.d/gierens.list
         sudo chmod 644 /etc/apt/keyrings/gierens.gpg /etc/apt/sources.list.d/gierens.list
@@ -77,40 +77,33 @@ fi
 echo "🔧 Installing additional tools..."
 
 # Install zoxide (smart cd)
-if ! command -v zoxide &> /dev/null; then
+if ! command -v zoxide &>/dev/null; then
     curl -sS https://raw.githubusercontent.com/ajeetdsouza/zoxide/main/install.sh | bash
     sudo mv ~/.local/bin/zoxide /usr/local/bin/
 fi
 
 # Install atuin (better history)
-if ! command -v atuin &> /dev/null; then
+if ! command -v atuin &>/dev/null; then
     bash <(curl https://raw.githubusercontent.com/atuinsh/atuin/main/install.sh)
-    sudo mv ~/.atuin/bin/atuin /usr/local/bin/ 2> /dev/null || true
+    sudo mv ~/.atuin/bin/atuin /usr/local/bin/ 2>/dev/null || true
 fi
 
 # Install uv (Python package manager)
-echo "🐍 Installing uv..."
-if ! command -v uv &> /dev/null; then
-    curl -LsSf https://astral.sh/uv/install.sh | sh
-fi
+ensure_tool uv "uv" 'curl -LsSf https://astral.sh/uv/install.sh | sh'
 
 # Ensure uv is in PATH for this session
 export PATH="$HOME/.local/bin:$PATH"
 
 # Install Rust toolchain via rustup
-echo "🦀 Installing rustup..."
-if ! command -v rustup &> /dev/null; then
-    curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --no-modify-path
-else
-    echo "✅ rustup already installed"
-fi
+ensure_tool rustup "rustup" \
+    "curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --no-modify-path"
 
 if [ -f "$HOME/.cargo/env" ]; then
     # Make cargo available immediately after rustup installation.
     . "$HOME/.cargo/env"
 fi
 
-if ! cargo --version &> /dev/null; then
+if ! cargo --version &>/dev/null; then
     echo "🦀 Configuring default Rust toolchain (stable)..."
     rustup default stable
 else
@@ -119,8 +112,8 @@ fi
 
 # Install zellij terminal multiplexer
 echo "🪟 Installing zellij..."
-if ! command -v zellij &> /dev/null; then
-    if sudo apt install -y zellij 2> /dev/null; then
+if ! command -v zellij &>/dev/null; then
+    if sudo apt install -y zellij 2>/dev/null; then
         echo "✅ zellij installed via apt"
     else
         echo "📥 zellij not available via apt, installing cargo build dependencies..."
@@ -135,16 +128,11 @@ echo "📝 Installing commitizen..."
 uv tool install commitizen
 
 # Install witr (weather tool)
-echo "🌤️ Installing witr..."
-if ! command -v witr &> /dev/null; then
-    curl -fsSL https://raw.githubusercontent.com/pranshuparmar/witr/main/install.sh | bash
-fi
+ensure_tool witr "witr" \
+    "curl -fsSL https://raw.githubusercontent.com/pranshuparmar/witr/main/install.sh | bash"
 
 # Install ekphos (Markdown notes app)
-echo "📝 Installing ekphos..."
-if ! command -v ekphos &> /dev/null; then
-    cargo install ekphos
-fi
+ensure_tool ekphos "ekphos" "cargo install ekphos"
 
 # Install Oh My Zsh
 echo "🎨 Installing Oh My Zsh..."
@@ -152,38 +140,18 @@ if [ ! -d "$HOME/.oh-my-zsh" ]; then
     sh -c "$(curl -fsSL https://raw.githubusercontent.com/ohmyzsh/ohmyzsh/master/tools/install.sh)" "" --unattended
 fi
 
-# Install Powerlevel10k theme
-echo "⚡ Installing Powerlevel10k theme..."
-if [ ! -d "${ZSH_CUSTOM:-$HOME/.oh-my-zsh/custom}/themes/powerlevel10k" ]; then
-    git clone --depth=1 https://github.com/romkatv/powerlevel10k.git ${ZSH_CUSTOM:-$HOME/.oh-my-zsh/custom}/themes/powerlevel10k
-fi
-
-# Install zsh plugins
-echo "🔌 Installing zsh plugins..."
+# Install Powerlevel10k theme and zsh plugins
 ZSH_CUSTOM=${ZSH_CUSTOM:-$HOME/.oh-my-zsh/custom}
-
-# zsh-autosuggestions
-if [ ! -d "$ZSH_CUSTOM/plugins/zsh-autosuggestions" ]; then
-    git clone https://github.com/zsh-users/zsh-autosuggestions $ZSH_CUSTOM/plugins/zsh-autosuggestions
-fi
-
-# zsh-syntax-highlighting
-if [ ! -d "$ZSH_CUSTOM/plugins/zsh-syntax-highlighting" ]; then
-    git clone https://github.com/zsh-users/zsh-syntax-highlighting.git $ZSH_CUSTOM/plugins/zsh-syntax-highlighting
-fi
-
-# zsh-abbr (for abbreviations)
-echo "🔌 Installing zsh-abbr..."
-if [ ! -d "$ZSH_CUSTOM/plugins/zsh-abbr" ]; then
-    git clone https://github.com/olets/zsh-abbr.git $ZSH_CUSTOM/plugins/zsh-abbr
-fi
-
-# zsh-autosuggestions-abbreviations-strategy
-echo "🔌 Installing zsh-autosuggestions-abbreviations-strategy..."
-if [ ! -d "$HOME/.local/share/zsh-autosuggestions-abbreviations-strategy" ]; then
-    git clone https://github.com/olets/zsh-autosuggestions-abbreviations-strategy.git \
-        "$HOME/.local/share/zsh-autosuggestions-abbreviations-strategy"
-fi
+ensure_repo "$ZSH_CUSTOM/themes/powerlevel10k" \
+    https://github.com/romkatv/powerlevel10k.git --depth=1
+ensure_repo "$ZSH_CUSTOM/plugins/zsh-autosuggestions" \
+    https://github.com/zsh-users/zsh-autosuggestions
+ensure_repo "$ZSH_CUSTOM/plugins/zsh-syntax-highlighting" \
+    https://github.com/zsh-users/zsh-syntax-highlighting.git
+ensure_repo "$ZSH_CUSTOM/plugins/zsh-abbr" \
+    https://github.com/olets/zsh-abbr.git
+ensure_repo "$HOME/.local/share/zsh-autosuggestions-abbreviations-strategy" \
+    https://github.com/olets/zsh-autosuggestions-abbreviations-strategy.git
 
 # Generate Shell Completions
 echo "📝 Generating shell completions..."
@@ -191,14 +159,14 @@ COMPLETIONS_DIR="$HOME/.local/share/zsh/completions"
 mkdir -p "$COMPLETIONS_DIR"
 
 # Generate uv completions
-if command -v uv &> /dev/null; then
-    uv generate-shell-completion zsh > "$COMPLETIONS_DIR/_uv"
-    uvx --generate-shell-completion zsh > "$COMPLETIONS_DIR/_uvx"
+if command -v uv &>/dev/null; then
+    uv generate-shell-completion zsh >"$COMPLETIONS_DIR/_uv"
+    uvx --generate-shell-completion zsh >"$COMPLETIONS_DIR/_uvx"
 fi
 
 # Generate atuin init script
-if command -v atuin &> /dev/null; then
-    atuin init zsh > "$COMPLETIONS_DIR/atuin-init.zsh"
+if command -v atuin &>/dev/null; then
+    atuin init zsh >"$COMPLETIONS_DIR/atuin-init.zsh"
     echo ">>> Importing shell history into atuin <<<"
     atuin import auto || {
         echo ">>> Warning: Failed to import shell history into atuin."

--- a/scripts/common.sh
+++ b/scripts/common.sh
@@ -1,6 +1,20 @@
 #!/bin/bash
+# ==============================================================================
+# Shared setup library for the dotfiles install scripts.
+#
+# Sourced by install_mac.sh, install_linux.sh and install_ubuntu_server.sh so
+# the installers call shared helpers instead of re-implementing the same phases
+# inline. Every helper is idempotent: safe to run repeatedly.
+# ==============================================================================
 set -e
 
+# ------------------------------------------------------------------------------
+# backup_if_exists <relative-path>
+#
+# Move an existing real file/dir at $HOME/<relative-path> out of the way before
+# stow creates a symlink. Existing symlinks are left untouched. Timestamped
+# backups never overwrite each other.
+# ------------------------------------------------------------------------------
 backup_if_exists() {
     local target="$HOME/$1"
     local timestamp
@@ -20,4 +34,50 @@ backup_if_exists() {
         echo "Backing up existing $target to $backup_path"
         mv "$target" "$backup_path"
     fi
+}
+
+# ------------------------------------------------------------------------------
+# ensure_tool <command> <description> <installer-command...>
+#
+# Install a CLI tool only when its <command> is not already on PATH. The
+# <installer-command...> is evaluated by the shell so pipelines and flags work
+# verbatim (e.g. "curl ... | sh").
+#
+#   ensure_tool uv "uv" 'curl -LsSf https://astral.sh/uv/install.sh | sh'
+# ------------------------------------------------------------------------------
+ensure_tool() {
+    local cmd="$1"
+    local desc="$2"
+    shift 2
+
+    if command -v "$cmd" &>/dev/null; then
+        echo ">>> $desc already installed <<<"
+        return 0
+    fi
+
+    echo ">>> Installing $desc <<<"
+    # Installer strings may contain pipelines/flags; evaluate as one command.
+    eval "$*"
+}
+
+# ------------------------------------------------------------------------------
+# ensure_repo <target-dir> <git-url> [git-clone-args...]
+#
+# git clone <git-url> into <target-dir> only when the directory does not yet
+# exist. Extra arguments are forwarded to git clone (e.g. --depth=1).
+# ------------------------------------------------------------------------------
+ensure_repo() {
+    local dir="$1"
+    local url="$2"
+    shift 2
+    local name
+    name="$(basename "$dir")"
+
+    if [ -d "$dir" ]; then
+        echo ">>> $name already installed <<<"
+        return 0
+    fi
+
+    echo ">>> Installing $name <<<"
+    git clone "$@" "$url" "$dir"
 }


### PR DESCRIPTION
## Candidate 2 of the architecture review — Strong

First of three stacked PRs deepening the install scripts. **Merge order: this → gen_completions → thin-recipes.**

### What
Introduces two idempotent helpers in `scripts/common.sh` and routes every tool-install and clone-if-missing block in all three installers through them:

- `ensure_tool <cmd> <desc> <installer>` — install only when `<cmd>` is absent.
- `ensure_repo <dir> <url> [clone-args]` — `git clone` only when `<dir>` is absent.

### Why
The "check present → install → announce" pattern was hand-inlined ~30 times across the three scripts, each drifting slightly. This collapses them onto two interfaces with consistent messaging and one place to change the pattern.

### Scope / behavior
- No behavior change. Same tools, same order, same idempotency.
- Platform-specific installs that don't fit the generic pattern (brew/paru bootstrap checks, apt multi-branch zoxide/atuin/zellij/eza) are intentionally left inline.

### Verification
- `bash -n` clean on all four files.
- pre-commit `shellcheck` + `shfmt` pass (idempotent).
- Helpers unit-tested in isolation (present → announce, absent → install, existing dir → skip).