### PR TITLE
refactor(install): table-driven gen_completions (candidate 3)

### DIFF
--- a/install_linux.sh
+++ b/install_linux.sh
@@ -236,51 +236,14 @@ uv tool install commitizen
 # ==============================================================================
 # 9. Generate Shell Completions (Pre-cached for faster shell startup)
 # ==============================================================================
-echo ">>> Generating shell completions <<<"
-COMPLETIONS_DIR="$HOME/.local/share/zsh/completions"
-mkdir -p "$COMPLETIONS_DIR"
-
-# Generate uv completions
-if command -v uv &>/dev/null; then
-    echo ">>> Generating uv/uvx completions <<<"
-    uv generate-shell-completion zsh >"$COMPLETIONS_DIR/_uv"
-    uvx --generate-shell-completion zsh >"$COMPLETIONS_DIR/_uvx"
-fi
-
-# Generate atuin init script
-if command -v atuin &>/dev/null; then
-    echo ">>> Generating atuin completions <<<"
-    atuin init zsh >"$COMPLETIONS_DIR/atuin-init.zsh"
-    echo ">>> Importing shell history into atuin <<<"
-    atuin import auto || {
-        echo ">>> Warning: Failed to import shell history into atuin."
-        echo ">>> Please check atuin logs or run 'atuin import auto' manually."
-    }
-fi
-
-# Generate GitHub CLI completions
-if command -v gh &>/dev/null; then
-    echo ">>> Generating gh completions <<<"
-    gh completion -s zsh >"$COMPLETIONS_DIR/_gh"
-fi
-
-# Generate Docker completions
-if command -v docker &>/dev/null; then
-    echo ">>> Generating docker completions <<<"
-    docker completion zsh >"$COMPLETIONS_DIR/_docker"
-fi
-
-# Generate kubectl completions (if installed)
-if command -v kubectl &>/dev/null; then
-    echo ">>> Generating kubectl completions <<<"
-    kubectl completion zsh >"$COMPLETIONS_DIR/_kubectl"
-fi
-
-# Generate helm completions (if installed)
-if command -v helm &>/dev/null; then
-    echo ">>> Generating helm completions <<<"
-    helm completion zsh >"$COMPLETIONS_DIR/_helm"
-fi
+gen_completions \
+    'uv:uv generate-shell-completion zsh > "$COMPLETIONS_DIR/_uv"; uvx --generate-shell-completion zsh > "$COMPLETIONS_DIR/_uvx"' \
+    'atuin:atuin init zsh > "$COMPLETIONS_DIR/atuin-init.zsh"' \
+    'gh:gh completion -s zsh > "$COMPLETIONS_DIR/_gh"' \
+    'docker:docker completion zsh > "$COMPLETIONS_DIR/_docker"' \
+    'kubectl:kubectl completion zsh > "$COMPLETIONS_DIR/_kubectl"' \
+    'helm:helm completion zsh > "$COMPLETIONS_DIR/_helm"'
+import_atuin_history
 
 # ==============================================================================
 # 10. Configure Docker

--- a/install_mac.sh
+++ b/install_mac.sh
@@ -86,51 +86,21 @@ ensure_repo "$ZSH_CUSTOM/plugins/zsh-syntax-highlighting" \
     https://github.com/zsh-users/zsh-syntax-highlighting.git
 
 # 7. Generate Static Completions (Pre-cached for faster shell startup)
-echo ">>> Generating shell completions <<<"
-COMPLETIONS_DIR="$HOME/.local/share/zsh/completions"
-mkdir -p "$COMPLETIONS_DIR"
-
-# Generate uv completions
-if command -v uv &>/dev/null; then
-    echo ">>> Generating uv/uvx completions <<<"
-    uv generate-shell-completion zsh >"$COMPLETIONS_DIR/_uv"
-    uvx --generate-shell-completion zsh >"$COMPLETIONS_DIR/_uvx"
+COMPLETION_ENTRIES=(
+    'uv:uv generate-shell-completion zsh > "$COMPLETIONS_DIR/_uv"; uvx --generate-shell-completion zsh > "$COMPLETIONS_DIR/_uvx"'
+    'atuin:atuin init zsh > "$COMPLETIONS_DIR/atuin-init.zsh"'
+    'gh:gh completion -s zsh > "$COMPLETIONS_DIR/_gh"'
+)
+# Docker/Kubernetes completions only for the full install.
+if [[ ! $MINIMAL_INSTALL =~ ^[Yy]$ ]]; then
+    COMPLETION_ENTRIES+=(
+        'docker:docker completion zsh > "$COMPLETIONS_DIR/_docker"'
+        'kubectl:kubectl completion zsh > "$COMPLETIONS_DIR/_kubectl"'
+        'helm:helm completion zsh > "$COMPLETIONS_DIR/_helm"'
+    )
 fi
-
-# Generate atuin init script
-if command -v atuin &>/dev/null; then
-    echo ">>> Generating atuin completions <<<"
-    atuin init zsh >"$COMPLETIONS_DIR/atuin-init.zsh"
-    echo ">>> Importing shell history into atuin <<<"
-    atuin import auto || {
-        echo ">>> Warning: Failed to import shell history into atuin."
-        echo ">>> Please check atuin logs or run 'atuin import auto' manually."
-    }
-fi
-
-# Generate GitHub CLI completions
-if command -v gh &>/dev/null; then
-    echo ">>> Generating gh completions <<<"
-    gh completion -s zsh >"$COMPLETIONS_DIR/_gh"
-fi
-
-# Generate Docker completions (full install only)
-if [[ ! $MINIMAL_INSTALL =~ ^[Yy]$ ]] && command -v docker &>/dev/null; then
-    echo ">>> Generating docker completions <<<"
-    docker completion zsh >"$COMPLETIONS_DIR/_docker"
-fi
-
-# Generate kubectl completions (full install only)
-if [[ ! $MINIMAL_INSTALL =~ ^[Yy]$ ]] && command -v kubectl &>/dev/null; then
-    echo ">>> Generating kubectl completions <<<"
-    kubectl completion zsh >"$COMPLETIONS_DIR/_kubectl"
-fi
-
-# Generate helm completions (full install only)
-if [[ ! $MINIMAL_INSTALL =~ ^[Yy]$ ]] && command -v helm &>/dev/null; then
-    echo ">>> Generating helm completions <<<"
-    helm completion zsh >"$COMPLETIONS_DIR/_helm"
-fi
+gen_completions "${COMPLETION_ENTRIES[@]}"
+import_atuin_history
 
 # 8. Link Dotfiles
 echo ">>> Linking dotfiles <<<"

--- a/install_ubuntu_server.sh
+++ b/install_ubuntu_server.sh
@@ -154,25 +154,10 @@ ensure_repo "$HOME/.local/share/zsh-autosuggestions-abbreviations-strategy" \
     https://github.com/olets/zsh-autosuggestions-abbreviations-strategy.git
 
 # Generate Shell Completions
-echo "📝 Generating shell completions..."
-COMPLETIONS_DIR="$HOME/.local/share/zsh/completions"
-mkdir -p "$COMPLETIONS_DIR"
-
-# Generate uv completions
-if command -v uv &>/dev/null; then
-    uv generate-shell-completion zsh >"$COMPLETIONS_DIR/_uv"
-    uvx --generate-shell-completion zsh >"$COMPLETIONS_DIR/_uvx"
-fi
-
-# Generate atuin init script
-if command -v atuin &>/dev/null; then
-    atuin init zsh >"$COMPLETIONS_DIR/atuin-init.zsh"
-    echo ">>> Importing shell history into atuin <<<"
-    atuin import auto || {
-        echo ">>> Warning: Failed to import shell history into atuin."
-        echo ">>> Please check atuin logs or run 'atuin import auto' manually."
-    }
-fi
+gen_completions \
+    'uv:uv generate-shell-completion zsh > "$COMPLETIONS_DIR/_uv"; uvx --generate-shell-completion zsh > "$COMPLETIONS_DIR/_uvx"' \
+    'atuin:atuin init zsh > "$COMPLETIONS_DIR/atuin-init.zsh"'
+import_atuin_history
 
 # Set zsh as default shell
 echo "🐚 Setting zsh as default shell..."

--- a/scripts/common.sh
+++ b/scripts/common.sh
@@ -81,3 +81,46 @@ ensure_repo() {
     echo ">>> Installing $name <<<"
     git clone "$@" "$url" "$dir"
 }
+
+# ------------------------------------------------------------------------------
+# gen_completions <tool:generator> ...
+#
+# Ensure the zsh completions directory exists, then for each "tool:generator"
+# pair run <generator> when <tool> is on PATH. <generator> is evaluated by the
+# shell so it may contain redirects and pipelines. The variable COMPLETIONS_DIR
+# is exported so generator strings can reference it.
+#
+#   gen_completions \
+#       'uv:uv generate-shell-completion zsh > "$COMPLETIONS_DIR/_uv"' \
+#       'gh:gh completion -s zsh > "$COMPLETIONS_DIR/_gh"'
+# ------------------------------------------------------------------------------
+gen_completions() {
+    echo ">>> Generating shell completions <<<"
+    export COMPLETIONS_DIR="$HOME/.local/share/zsh/completions"
+    mkdir -p "$COMPLETIONS_DIR"
+
+    local entry tool generator
+    for entry in "$@"; do
+        tool="${entry%%:*}"
+        generator="${entry#*:}"
+        if command -v "$tool" &>/dev/null; then
+            echo ">>> Generating $tool completions <<<"
+            eval "$generator"
+        fi
+    done
+}
+
+# ------------------------------------------------------------------------------
+# import_atuin_history
+#
+# Import existing shell history into atuin when atuin is installed. Non-fatal on
+# failure so a broken import never aborts the installer.
+# ------------------------------------------------------------------------------
+import_atuin_history() {
+    command -v atuin &>/dev/null || return 0
+    echo ">>> Importing shell history into atuin <<<"
+    atuin import auto || {
+        echo ">>> Warning: Failed to import shell history into atuin."
+        echo ">>> Please check atuin logs or run 'atuin import auto' manually."
+    }
+}


### PR DESCRIPTION
## Candidate 3 of the architecture review — Worth exploring

Second of three stacked PRs. **Targets `refactor/install-ensure-helpers` (PR #60), not main** — review/merge #60 first.

### What
Replaces the per-tool completion blocks (6 in mac, 6 in linux, 2 in ubuntu) with one table-driven helper:

```sh
gen_completions \
    'uv:uv generate-shell-completion zsh > "$COMPLETIONS_DIR/_uv"; ...' \
    'gh:gh completion -s zsh > "$COMPLETIONS_DIR/_gh"'
```

Plus `import_atuin_history` extracted as its own non-fatal helper.

### Why
Six near-identical guarded blocks that varied only by tool name and output file. Now: data (the table) is separate from mechanism (mkdir + guard + write). Adding a tool is one entry.

### Scope / behavior
- No behavior change. Same completions generated under the same conditions (mac still gates docker/kubectl/helm on full install).
- atuin history import preserved via `import_atuin_history` (non-fatal).

### Verification
- `bash -n` clean; pre-commit shellcheck + shfmt pass.
- `gen_completions` unit-tested: generates present tools, skips absent ones; `import_atuin_history` no-ops/warns non-fatally.