### PR TITLE
fix(nvim): update integrations for AstroNvim 6

### DIFF
--- a/nvim/.config/nvim/README.md
+++ b/nvim/.config/nvim/README.md
@@ -93,7 +93,7 @@ This file includes:
 - `lsp_signature.nvim`
 - `oil.nvim`
 - `nvim-surround`
-- custom `alpha-nvim` header
+- custom `snacks.nvim` dashboard header
 - `LuaSnip` filetype extension for JavaScript
 - custom `nvim-autopairs` rules
 

--- a/nvim/.config/nvim/lazy-lock.json
+++ b/nvim/.config/nvim/lazy-lock.json
@@ -3,7 +3,6 @@
   "FixCursorHold.nvim": { "branch": "master", "commit": "1900f89dc17c603eec29960f57c00bd9ae696495" },
   "LuaSnip": { "branch": "master", "commit": "642b0c595e11608b4c18219e93b88d7637af27bc" },
   "aerial.nvim": { "branch": "master", "commit": "28fe6e822ae344544c379d60fcb13c9519a1f08a" },
-  "alpha-nvim": { "branch": "main", "commit": "6c6a89d5b068b5251c8bdf0dd57bb921bcfeeb09" },
   "astrocommunity": { "branch": "main", "commit": "ac92a365ce2e9f7ab8c4c25070e8b429e3875096" },
   "astrocore": { "branch": "main", "commit": "a9217f7145b7fcd6b220a7f46e725e252ef64565" },
   "astrolsp": { "branch": "main", "commit": "ebc1676127b3bfbd46e3e26589b104853cac3730" },

--- a/nvim/.config/nvim/lua/plugins/astrolsp.lua
+++ b/nvim/.config/nvim/lua/plugins/astrolsp.lua
@@ -38,9 +38,10 @@ return {
     },
     -- enable servers that you already have installed without mason
     servers = {
+      "ruff",
       "ty",
     },
-    -- customize language server configuration options passed to `lspconfig`
+    -- customize language server configuration options passed to `vim.lsp.config`
     ---@diagnostic disable: missing-fields
     config = {
       ruff = {
@@ -53,26 +54,17 @@ return {
       ty = {
         cmd = { "ty", "server" },
         filetypes = { "python" },
-        root_dir = function(fname)
-          return require("lspconfig.util").root_pattern("pyproject.toml", "ty.toml", "setup.py", "setup.cfg", ".git")(
-            fname
-          )
+        root_dir = function(bufnr, on_dir)
+          local root = vim.fs.root(bufnr, { "ty.toml", "pyproject.toml", "setup.py", "setup.cfg", ".git" })
+          on_dir(root or vim.fs.dirname(vim.api.nvim_buf_get_name(bufnr)))
         end,
-        single_file_support = true,
       },
     },
-    -- customize how language servers are attached
+    -- customize which language servers AstroLSP enables
     handlers = {
-      -- a function without a key is simply the default handler, functions take two parameters, the server name and the configured options table for that server
-      -- function(server, opts) require("lspconfig")[server].setup(opts) end
-
-      -- the key is the server that is being setup with `lspconfig`
-      -- rust_analyzer = false, -- setting a handler to false will disable the set up of that language server
-      -- pyright = function(_, opts) require("lspconfig").pyright.setup(opts) end -- or a custom handler function can be passed
+      -- setting a handler to false disables that language server
       basedpyright = false,
       pyright = false,
-      ruff = function(_, opts) require("lspconfig").ruff.setup(opts) end,
-      ty = function(_, opts) require("lspconfig").ty.setup(opts) end,
     },
     -- Configure buffer local auto commands to add when attaching a language server
     autocmds = {
@@ -108,8 +100,8 @@ return {
         ["<Leader>uY"] = {
           function() require("astrolsp.toggles").buffer_semantic_tokens() end,
           desc = "Toggle LSP semantic highlight (buffer)",
-          cond = function(client)
-            return client.supports_method "textDocument/semanticTokens/full" and vim.lsp.semantic_tokens
+          cond = function(client, bufnr)
+            return client:supports_method("textDocument/semanticTokens/full", bufnr) and vim.lsp.semantic_tokens
           end,
         },
       },

--- a/nvim/.config/nvim/lua/plugins/astrolsp.lua
+++ b/nvim/.config/nvim/lua/plugins/astrolsp.lua
@@ -56,7 +56,12 @@ return {
         filetypes = { "python" },
         root_dir = function(bufnr, on_dir)
           local root = vim.fs.root(bufnr, { "ty.toml", "pyproject.toml", "setup.py", "setup.cfg", ".git" })
-          on_dir(root or vim.fs.dirname(vim.api.nvim_buf_get_name(bufnr)))
+          if root then
+            on_dir(root)
+          else
+            local buffer_name = vim.api.nvim_buf_get_name(bufnr)
+            on_dir(buffer_name ~= "" and vim.fs.dirname(buffer_name) or vim.uv.cwd())
+          end
         end,
       },
     },

--- a/nvim/.config/nvim/lua/plugins/user.lua
+++ b/nvim/.config/nvim/lua/plugins/user.lua
@@ -25,12 +25,11 @@ return {
     opts = {},
   },
 
-  -- customize alpha options
+  -- customize the Snacks dashboard header
   {
-    "goolord/alpha-nvim",
+    "folke/snacks.nvim",
     opts = function(_, opts)
-      -- customize the dashboard header
-      opts.section.header.val = {
+      opts.dashboard.preset.header = table.concat({
         " █████  ███████ ████████ ██████   ██████",
         "██   ██ ██         ██    ██   ██ ██    ██",
         "███████ ███████    ██    ██████  ██    ██",
@@ -42,7 +41,7 @@ return {
         "    ██ ██  ██ ██    ██ ██ ██ ████ ██",
         "    ██  ██ ██  ██  ██  ██ ██  ██  ██",
         "    ██   ████   ████   ██ ██      ██",
-      }
+      }, "\n")
       return opts
     end,
   },


### PR DESCRIPTION
## Summary

- migrate the custom dashboard header from alpha-nvim to snacks.nvim
- update AstroLSP configuration for the current Neovim LSP API
- enable and verify the Ruff and ty Python language servers

## Testing

- `pre-commit run`
- headless Neovim startup
- Python buffer with both `ruff` and `ty` attached